### PR TITLE
fix: stop the nightly sweep running into the working day

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -355,6 +355,16 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public int JobMaxRetries { get; set; } = 3;
 
+        /// <summary>
+        /// Wall-clock cap on a single sweep of the Generate Subtitles task, in hours. The per-call
+        /// deadlines above bound one transcription; nothing bounded the sweep itself, so a large library
+        /// could keep the task running deep into the day, holding a database connection and saturating
+        /// disk I/O the whole time. When the cap is reached the sweep stops cleanly between items:
+        /// finished work is kept, the skip cache is persisted, and the next scheduled run resumes from
+        /// where this one stopped. 0 = unlimited (the behaviour before this setting). Default 6.
+        /// </summary>
+        public int TaskMaxRuntimeHours { get; set; } = 6;
+
         // ── Worker pool (v4.0; power-user feature, empty by default) ─────────
         // Simple by default: a normal single-server install leaves Workers empty and EnableLocalWorker on,
         // so the plugin behaves exactly as today (the host's own whisper, one job at a time). Power users

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -226,6 +226,19 @@ namespace WhisperSubs.ScheduledTasks
                 _logger.LogInformation("Sweep budget: {Hours}h (stops cleanly between items; next run resumes)", config.TaskMaxRuntimeHours);
             }
 
+            // Every pre-dispatch wait below (playback idle, priority drain, parking on AcquireAsync)
+            // can outlast a budget that was still valid at loop entry, so the check is re-run after
+            // each of them rather than once per item. Logs only on the call that actually stops.
+            bool SweepBudgetExhausted()
+            {
+                if (!SweepBudget.Expired(sweepDeadline, DateTime.UtcNow)) return false;
+                _logger.LogWarning(
+                    "Stopping this sweep after {Hours}h (TaskMaxRuntimeHours): {Done}/{Total} item(s) processed. " +
+                    "Finished work is kept and the next scheduled run continues from here.",
+                    config.TaskMaxRuntimeHours, Volatile.Read(ref completed), allItems.Count);
+                return true;
+            }
+
             var inFlight = new List<Task>();
             if (pool.TotalCapacity > 1)
             {
@@ -241,14 +254,7 @@ namespace WhisperSubs.ScheduledTasks
                 // Stop cleanly at the sweep budget rather than running into the day. Breaking (not
                 // throwing) lets the finally below persist the skip cache, so the next scheduled run
                 // resumes from here instead of re-probing everything already done.
-                if (SweepBudget.Expired(sweepDeadline, DateTime.UtcNow))
-                {
-                    _logger.LogWarning(
-                        "Stopping this sweep after {Hours}h (TaskMaxRuntimeHours): {Done}/{Total} item(s) processed. " +
-                        "Finished work is kept and the next scheduled run continues from here.",
-                        config.TaskMaxRuntimeHours, Volatile.Read(ref completed), allItems.Count);
-                    break;
-                }
+                if (SweepBudgetExhausted()) break;
 
                 // Wait for active playback to finish before processing next item
                 if (config.PauseOnPlayback)
@@ -262,6 +268,9 @@ namespace WhisperSubs.ScheduledTasks
                     _logger.LogInformation("Pausing auto-generation to process {Count} priority request(s)", queue.PriorityCount);
                     await queue.DrainPriorityAsync(manager, pool, requirements, config.JobMaxRetries, _logger, cancellationToken);
                 }
+
+                // Either wait above can run for hours; do not start another item past the budget.
+                if (SweepBudgetExhausted()) break;
 
                 var (item, libName) = allItems[i];
                 var itemType = item.GetType().Name;
@@ -464,6 +473,14 @@ namespace WhisperSubs.ScheduledTasks
                         _logger.LogInformation("Yielding worker slot to {Count} priority request(s) before the next swept item", queue.PriorityCount);
                         await queue.DrainPriorityAsync(manager, pool, requirements, config.JobMaxRetries, _logger, cancellationToken);
                         lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    }
+
+                    // Parking on AcquireAsync (and any priority drain above) can outlast the budget.
+                    // Hand the slot straight back instead of starting a transcription past the deadline.
+                    if (SweepBudgetExhausted())
+                    {
+                        pool.Release(lease.Key);
+                        break;
                     }
 
                     // Report AFTER the slot is won, so the panel names the item that is actually starting —

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -220,6 +220,12 @@ namespace WhisperSubs.ScheduledTasks
             // items are ever in flight. With the default one local worker (TotalCapacity 1) the producer
             // cannot dispatch item k+1 until item k releases its slot — transcriptions stay strictly
             // one-at-a-time in enumeration order, exactly like the old inline await.
+            var sweepDeadline = SweepBudget.Deadline(config.TaskMaxRuntimeHours, DateTime.UtcNow);
+            if (sweepDeadline.HasValue)
+            {
+                _logger.LogInformation("Sweep budget: {Hours}h (stops cleanly between items; next run resumes)", config.TaskMaxRuntimeHours);
+            }
+
             var inFlight = new List<Task>();
             if (pool.TotalCapacity > 1)
             {
@@ -231,6 +237,18 @@ namespace WhisperSubs.ScheduledTasks
             for (int i = 0; i < allItems.Count; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Stop cleanly at the sweep budget rather than running into the day. Breaking (not
+                // throwing) lets the finally below persist the skip cache, so the next scheduled run
+                // resumes from here instead of re-probing everything already done.
+                if (SweepBudget.Expired(sweepDeadline, DateTime.UtcNow))
+                {
+                    _logger.LogWarning(
+                        "Stopping this sweep after {Hours}h (TaskMaxRuntimeHours): {Done}/{Total} item(s) processed. " +
+                        "Finished work is kept and the next scheduled run continues from here.",
+                        config.TaskMaxRuntimeHours, Volatile.Read(ref completed), allItems.Count);
+                    break;
+                }
 
                 // Wait for active playback to finish before processing next item
                 if (config.PauseOnPlayback)

--- a/ScheduledTasks/SweepBudget.cs
+++ b/ScheduledTasks/SweepBudget.cs
@@ -13,7 +13,14 @@ namespace WhisperSubs.ScheduledTasks
         /// disabled (<paramref name="maxRuntimeHours"/> of 0 or less means unlimited).
         /// </summary>
         internal static DateTime? Deadline(int maxRuntimeHours, DateTime startUtc)
-            => maxRuntimeHours > 0 ? startUtc.AddHours(maxRuntimeHours) : (DateTime?)null;
+        {
+            if (maxRuntimeHours <= 0) return null;
+
+            // A misconfigured huge value must not throw out of AddHours and kill the task; an
+            // unreachable deadline behaves like "effectively unlimited", which is what was asked for.
+            var remainingHours = (DateTime.MaxValue - startUtc).TotalHours;
+            return maxRuntimeHours >= remainingHours ? DateTime.MaxValue : startUtc.AddHours(maxRuntimeHours);
+        }
 
         /// <summary>True once <paramref name="nowUtc"/> has reached a real deadline.</summary>
         internal static bool Expired(DateTime? deadline, DateTime nowUtc)

--- a/ScheduledTasks/SweepBudget.cs
+++ b/ScheduledTasks/SweepBudget.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace WhisperSubs.ScheduledTasks
+{
+    /// <summary>
+    /// Wall-clock budget for one sweep of the subtitle generation task.
+    /// Kept separate from the task so the boundary is unit-testable without a Jellyfin host.
+    /// </summary>
+    internal static class SweepBudget
+    {
+        /// <summary>
+        /// Deadline for a sweep started at <paramref name="startUtc"/>, or null when the cap is
+        /// disabled (<paramref name="maxRuntimeHours"/> of 0 or less means unlimited).
+        /// </summary>
+        internal static DateTime? Deadline(int maxRuntimeHours, DateTime startUtc)
+            => maxRuntimeHours > 0 ? startUtc.AddHours(maxRuntimeHours) : (DateTime?)null;
+
+        /// <summary>True once <paramref name="nowUtc"/> has reached a real deadline.</summary>
+        internal static bool Expired(DateTime? deadline, DateTime nowUtc)
+            => deadline.HasValue && nowUtc >= deadline.Value;
+    }
+}

--- a/WhisperSubs.Tests/SweepBudgetTests.cs
+++ b/WhisperSubs.Tests/SweepBudgetTests.cs
@@ -1,0 +1,72 @@
+using System;
+using WhisperSubs.ScheduledTasks;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Locks the wall-clock budget for one sweep of the subtitle generation task. Per-call deadlines
+/// already bound a single transcription; this bounds the sweep itself, which is what let a run
+/// continue for eleven hours into the working day. The contract: 0 or less means unlimited (the
+/// behaviour before the setting existed), a positive value produces a deadline that many hours after
+/// the start, and the boundary instant counts as expired so the sweep never overshoots.
+/// </summary>
+public class SweepBudgetTests
+{
+    private static readonly DateTime Start = new(2026, 8, 24, 2, 0, 0, DateTimeKind.Utc);
+
+    // ---- disabled: unlimited, exactly as before the setting existed ----------------------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void NonPositiveHours_MeansUnlimited(int hours)
+    {
+        var deadline = SweepBudget.Deadline(hours, Start);
+
+        Assert.Null(deadline);
+        Assert.False(SweepBudget.Expired(deadline, Start.AddYears(5)));
+    }
+
+    // ---- enabled: deadline is start + N hours ---------------------------------------------------
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(6)]
+    [InlineData(24)]
+    public void PositiveHours_DeadlineIsStartPlusHours(int hours)
+    {
+        Assert.Equal(Start.AddHours(hours), SweepBudget.Deadline(hours, Start));
+    }
+
+    [Fact]
+    public void NotExpired_BeforeTheDeadline()
+    {
+        var deadline = SweepBudget.Deadline(6, Start);
+
+        Assert.False(SweepBudget.Expired(deadline, Start));
+        Assert.False(SweepBudget.Expired(deadline, Start.AddHours(5).AddMinutes(59)));
+    }
+
+    [Fact]
+    public void Expired_AtTheDeadlineInstantAndAfter()
+    {
+        var deadline = SweepBudget.Deadline(6, Start);
+
+        // The boundary itself counts, so a sweep stops at the budget rather than one item past it.
+        Assert.True(SweepBudget.Expired(deadline, Start.AddHours(6)));
+        Assert.True(SweepBudget.Expired(deadline, Start.AddHours(11)));
+    }
+
+    // ---- the real incident: 02:00 start, still running at 13:00 ---------------------------------
+
+    [Fact]
+    public void SixHourDefault_WouldHaveStoppedTheElevenHourRun()
+    {
+        var deadline = SweepBudget.Deadline(6, Start);
+
+        var whenItWasFoundStillRunning = new DateTime(2026, 8, 24, 13, 0, 0, DateTimeKind.Utc);
+        Assert.True(SweepBudget.Expired(deadline, whenItWasFoundStillRunning));
+    }
+}

--- a/WhisperSubs.Tests/SweepBudgetTests.cs
+++ b/WhisperSubs.Tests/SweepBudgetTests.cs
@@ -59,6 +59,21 @@ public class SweepBudgetTests
         Assert.True(SweepBudget.Expired(deadline, Start.AddHours(11)));
     }
 
+    // ---- a misconfigured huge value must not throw out of AddHours ------------------------------
+
+    [Theory]
+    [InlineData(int.MaxValue)]
+    [InlineData(1_000_000_000)]
+    public void AbsurdlyLargeHours_SaturateInsteadOfThrowing(int hours)
+    {
+        // AddHours would throw ArgumentOutOfRangeException and kill the task. Saturating gives an
+        // unreachable deadline, which is the "effectively unlimited" the operator asked for.
+        var deadline = SweepBudget.Deadline(hours, Start);
+
+        Assert.Equal(DateTime.MaxValue, deadline);
+        Assert.False(SweepBudget.Expired(deadline, new DateTime(9999, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
     // ---- the real incident: 02:00 start, still running at 13:00 ---------------------------------
 
     [Fact]


### PR DESCRIPTION
## The problem

On 24 Aug the daily **Generate Subtitles** task started at 02:00 and was still running at 13:00, at 2.5% complete. Eleven hours in, well past any night window.

While it ran it pinned `shfs` (the Unraid user-share layer) at 100% CPU, which slows every file operation through `/mnt/user` — including the 2 GB `jellyfin.db` sitting on appdata. Jellyfin logged **3,126 optimistic-lock retries** that day and its write-ahead log grew to **2.24 GB** because autocheckpoint never got a clean window.

The per-call deadlines added in v4.0 (`JobTimeoutRealtimeFactor`, `JobMinTimeoutSeconds`, `JobMaxTimeoutHours`) each bound a *single* transcription. Nothing bounded the sweep, so on a large library the task simply keeps going.

## The fix

`TaskMaxRuntimeHours`, default 6, `0` = unlimited (the previous behaviour, so this is fully opt-out-able).

The sweep stops **cleanly between items** rather than throwing. That matters: breaking lets the existing `finally` persist the skip cache, so finished work is kept and the next scheduled run continues from where this one stopped instead of re-probing everything already done. An in-flight transcription is not interrupted.

The boundary logic lives in a small `SweepBudget` helper so it is unit-testable without a Jellyfin host.

## Verification

- `dotnet build` — succeeded, 0 warnings, 0 errors.
- Full suite — **1,456 passed, 0 failed**.
- 9 new tests, including the real incident: a 02:00 start with the 6h default is expired by 13:00.
- **Mutation check**: flipping the boundary from `>=` to `>` fails exactly 1 test; restoring makes it green again. The tests can actually go red.

Config-file-only, with no config-page field, matching how `JobMaxRetries` is exposed today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable maximum runtime for each subtitle-generation sweep.
  - Sweeps now stop cleanly after the configured limit, allowing active items to finish and preserving progress for the next scheduled run.
  - The default limit is six hours; set the value to 0 to allow unlimited runtime.

- **Bug Fixes**
  - Improved long-running subtitle generation by preventing a single sweep from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->