### PR TITLE
chore(release): 4.8.0.0 — ship the sweep runtime cap

### DIFF
--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.7.0.1</Version>
+    <Version>4.8.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Releases the change merged in #159.

`build-release.yml` reads `<Version>` from `WhisperSubs.csproj` and skips the release when `v$VERSION` already exists, so merging #159 built nothing new — the run on `a851e1c2` reported success with every build job skipped and `v4.7.0.1` still the newest tag. This bump is what actually ships it.

Minor rather than patch: it adds a first-class `TaskMaxRuntimeHours` setting and changes default behaviour (a sweep now stops after 6h instead of running unbounded). That matches how 4.6.0.0 shipped the `--max-len` cap, whereas the 4th component is used for pure fixes.