### PR TITLE
fix: publish the setup guide the plugin already links to

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -332,8 +332,19 @@ jobs:
 
       - name: Prepare Pages content
         run: |
-          mkdir -p _pages
+          mkdir -p _pages/docs
           cp manifest.json _pages/
+          cp -r docs/setup _pages/docs/
+
+      - name: Gate - the catalog must be in the artifact and valid
+        run: |
+          set -euo pipefail
+          test -f _pages/manifest.json
+          jq -e 'type == "array"' _pages/manifest.json > /dev/null
+          jq -e '.[0].guid == "97124bd9-c8cd-4a53-a213-e593aa3fef52"' _pages/manifest.json > /dev/null
+          test -f _pages/docs/setup/index.html
+          V=$(jq -er '.[0].versions[0].version' _pages/manifest.json)
+          echo "gate ok: publishing catalog newest=$V plus docs/setup"
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/manifest.json
+++ b/manifest.json
@@ -8,44 +8,44 @@
     "category": "Subtitles",
     "versions": [
       {
-        "version": "3.17.0.0",
+        "version": "4.8.0.0",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.17.0.0/WhisperSubs_3.17.0.0.zip",
-        "checksum": "d6ce12b9241b064b7e6f852017f84eb4",
-        "timestamp": "2026-05-12T09:15:19Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v4.8.0.0/WhisperSubs_4.8.0.0.zip",
+        "checksum": "3bb0436171b861b6f25856217b81b488",
+        "timestamp": "2026-08-24T21:28:48Z"
       },
       {
-        "version": "3.16.0.0",
+        "version": "4.7.0.1",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.16.0.0/WhisperSubs_3.16.0.0.zip",
-        "checksum": "67089ffc4844d631f1a58ffe286bf454",
-        "timestamp": "2026-05-11T10:49:18Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v4.7.0.1/WhisperSubs_4.7.0.1.zip",
+        "checksum": "296706be5216ce49e94887a5ce4f1122",
+        "timestamp": "2026-08-19T12:55:58Z"
       },
       {
-        "version": "3.15.0.0",
+        "version": "4.7.0.0",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.15.0.0/WhisperSubs_3.15.0.0.zip",
-        "checksum": "01a051fb6a6c0956bd441676349a64f3",
-        "timestamp": "2026-05-11T09:36:39Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v4.7.0.0/WhisperSubs_4.7.0.0.zip",
+        "checksum": "d5cd213de795f8d39254099b65b85169",
+        "timestamp": "2026-08-10T22:09:41Z"
       },
       {
-        "version": "3.14.2.0",
+        "version": "4.6.0.1",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.14.2.0/WhisperSubs_3.14.2.0.zip",
-        "checksum": "5ef4abc9d9c73d1088b1d1b7934a3421",
-        "timestamp": "2026-05-07T22:59:39Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v4.6.0.1/WhisperSubs_4.6.0.1.zip",
+        "checksum": "b274563e322051c25bc5dcef59819528",
+        "timestamp": "2026-08-06T23:33:24Z"
       },
       {
-        "version": "3.14.1.0",
+        "version": "4.6.0.0",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.14.1.0/WhisperSubs_3.14.1.0.zip",
-        "checksum": "8dcbeae7fbc9c01c6184ec2cf8ef5aca",
-        "timestamp": "2026-05-07T21:48:47Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v4.6.0.0/WhisperSubs_4.6.0.0.zip",
+        "checksum": "52fe46e2b285a8c532ee7a7cfb86c519",
+        "timestamp": "2026-08-06T12:18:30Z"
       }
     ]
   }


### PR DESCRIPTION
Someone opened #162 to say our documentation link is broken. They are right, and it is worse than a broken link: the setup guide exists, is committed, and has been kept up to date — it has just never been uploaded.

The Pages job builds the published site with `mkdir -p _pages && cp manifest.json _pages/`. That is the whole site. `docs/setup/index.html` has never been part of it, so the URL has 404'd since the day it shipped.

That link cannot be fixed by editing HTML. `Web/configPage.html` is an `EmbeddedResource` compiled into the DLL, so the URL is baked into every installed copy — 61 of 102 releases carry it, covering 97.6% of all downloads. Changing the link only helps people who update. Publishing the page fixes everyone who already has it installed, immediately, with no action on their part.

## What this does

Publishes `docs/setup` alongside the catalog, and gates the deploy on the catalog being valid.

The gate matters because a Pages deployment replaces the entire site — there is no merge with what was there before. An artifact that omits `manifest.json` would take the plugin repository offline for every installed user. The gate fails the build instead of shipping that, and it also catches a subtler case: a docs generator emitting its own PWA `manifest.json` at the site root would serve HTTP 200 with the wrong JSON, which no status-code check would ever notice. Verified red against all four failure modes before trusting it.

It also seeds `manifest.json` from the live catalog. The committed copy was pinned at 3.17.0.0 while production served 4.8.0.0, and that file is the fallback the release job uses when the live fetch fails — so the stale copy was one failed `curl` away from silently republishing 3.x builds as the current version.

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Releases**
  - Added WhisperSubs versions 4.8.0.0 through 4.6.0.0 to the release catalog, including download links, checksums, and timestamps.
  - Older versions 3.17.0.0 through 3.14.1.0 are no longer listed.

- **Documentation**
  - Setup documentation is now included with the published Pages content.

- **Bug Fixes**
  - Added publication checks to verify catalog validity, expected plugin details, setup documentation availability, and version information before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->