### PR TITLE
fix(deps): clear the fixable npm advisories and let Dependabot watch the site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,8 +49,11 @@ updates:
         patterns:
           - '*'
     ignore:
-      # Docusaurus majors change config and theme APIs; take those deliberately.
-      - dependency-name: '*'
+      # Docusaurus majors change config and theme APIs, so take those
+      # deliberately. Scoped to Docusaurus rather than '*': a blanket major
+      # ignore also silences security fixes that need a major bump, which is
+      # how Action majors drifted unnoticed elsewhere.
+      - dependency-name: '@docusaurus/*'
         update-types:
           - version-update:semver-major
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,32 @@ updates:
           - version-update:semver-major
       - dependency-name: Jellyfin.Controller
       - dependency-name: Jellyfin.Model
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: deps
+    labels:
+      - dependencies
+      - automated
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+      npm_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+    ignore:
+      # Docusaurus majors change config and theme APIs; take those deliberately.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7152,22 +7152,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
-      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bonjour-service": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
@@ -16385,9 +16369,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -16430,15 +16414,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -17426,12 +17401,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -18908,13 +18883,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/site/package.json
+++ b/site/package.json
@@ -45,5 +45,10 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.1.1",
+    "qs": "^6.16.0",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
The documentation site brought a Node dependency tree with it, and seven Dependabot alerts followed. This clears every one that has a fix, and explains the two that do not.

## Why `npm audit fix` was no use

Docusaurus pins the affected transitive packages, so npm reports `fixAvailable: false` for all 26 findings. Overrides are what actually move them:

| Package | Was | Now | Advisories cleared |
|---|---|---|---|
| `serialize-javascript` | 6.0.2 | 7.1.1 | RCE via `RegExp.flags`, CPU-exhaustion DoS |
| `qs` | 6.15.3 | 6.16.0 | array-limit bypass, DoS via attacker-controlled `isBuffer` |
| `uuid` | 8.3.2 | 11.1.1 | missing buffer bounds check in v3/v5/v6 |

26 audit findings drop to 17, every moderate is gone, and the site still builds with all seven pages emitted, `/docs/setup/` included. Those are major bumps across three packages, so the build passing is the point of the exercise, not a formality.

## `image-size` has no fix

2.0.2 is both the latest published release and the vulnerable one, so there is nothing to upgrade to. It accounts for all 17 remaining findings, propagating through `@docusaurus/mdx-loader` into every Docusaurus package.

Both advisories are denial of service in its **ICNS, JXL and HEIF** parsers. This site ships one `.ico` and one `.png`, so those code paths are never reached, and the build runs in CI over files in this repository rather than anything user-supplied. The published output is static HTML: none of this ships to anyone.

Worth revisiting when upstream publishes a fix, which is what the Dependabot change below is for.

## Dependabot was not watching npm

`.github/dependabot.yml` covered `nuget` and `github-actions` only, so nothing would ever have opened an update PR for `site/`. It now covers `/site` on the same weekly cadence as nuget, grouping minor and patch updates, with majors left to be taken deliberately since Docusaurus majors change config and theme APIs.

That is the part that keeps this from recurring: the overrides fix today's alerts, the config is what surfaces tomorrow's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added weekly automated updates for eligible dependencies.
  - Added version overrides to ensure selected dependencies use approved versions.
  - Configured security updates separately from routine updates.
  - Grouped minor and patch updates to simplify maintenance.
  - Improved coverage for security fixes that require major-version upgrades outside the documentation platform packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->