### PR TITLE
feat: target Jellyfin 12.0 / .NET 10.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore
@@ -232,8 +232,8 @@ jobs:
           fi
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           mkdir -p release
-          cp bin/Release/net9.0/WhisperSubs.dll release/
-          cp bin/Release/net9.0/WhisperSubs.pdb release/
+          cp bin/Release/net10.0/WhisperSubs.dll release/
+          cp bin/Release/net10.0/WhisperSubs.pdb release/
           jq -n \
             --arg version "$VERSION" \
             --arg timestamp "$TIMESTAMP" \
@@ -245,7 +245,7 @@ jobs:
               name: "WhisperSubs",
               overview: "Generate subtitles using local or remote Whisper workers.",
               owner: "GeiserX",
-              targetAbi: "10.11.0.0",
+              targetAbi: "12.0.0.0",
               timestamp: $timestamp,
               version: $version,
               status: "Active",
@@ -285,7 +285,7 @@ jobs:
             --arg ver "$VERSION" \
             --arg cs "$CHECKSUM" \
             --arg ts "$TIMESTAMP" \
-            '{version: $ver, changelog: "See https://github.com/GeiserX/whisper-subs/releases", targetAbi: "10.11.0.0", sourceUrl: "https://github.com/GeiserX/whisper-subs/releases/download/v\($ver)/WhisperSubs_\($ver).zip", checksum: $cs, timestamp: $ts}')
+            '{version: $ver, changelog: "See https://github.com/GeiserX/whisper-subs/releases", targetAbi: "12.0.0.0", sourceUrl: "https://github.com/GeiserX/whisper-subs/releases/download/v\($ver)/WhisperSubs_\($ver).zip", checksum: $cs, timestamp: $ts}')
 
           # Fetch live manifest from Pages (has accumulated history)
           LIVE_MANIFEST=$(curl -sf https://geiserx.github.io/whisper-subs/manifest.json || echo "")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
           cache: true
           cache-dependency-path: '**/*.csproj'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@
 Jellyfin plugin for AI-powered subtitle generation using whisper.cpp. By default all transcription runs on this Jellyfin server (no third-party services). Optionally, the v4.0 worker pool distributes transcription across additional self-hosted — or cloud — OpenAI-compatible workers; when workers are configured, the plugin extracts audio locally and sends it over HTTP to the workers you set up. Supports GPU acceleration (CUDA, Vulkan, ROCm).
 
 - **Plugin GUID:** `97124bd9-c8cd-4a53-a213-e593aa3fef52`
-- **Target:** Jellyfin 10.11+ / .NET 9.0
+- **Target:** Jellyfin 12.0+ / .NET 10.0
 
 ## Tech Stack
-- C# / .NET 9.0
-- Jellyfin Plugin API (10.11+)
+- C# / .NET 10.0
+- Jellyfin Plugin API (12.0+)
 - whisper.cpp (local AI inference)
 - xUnit for testing (`WhisperSubs.Tests/`)
 - GitHub Actions for CI/build/release
@@ -264,7 +264,7 @@ Version is read from `<Version>` in `WhisperSubs.csproj`. Bump there before push
 - **Orphaned docker-proxy**: If Jellyfin crashes, docker-proxy may hold port 8096. On Unraid: `rc.docker restart`.
 - **Memory limits**: Large models consume 5-10 GB RAM. Set `mem_limit` in docker-compose.
 - **Plugin directory moves on version change**: Always check actual path with `docker exec jellyfin find /config/plugins -name "WhisperSubs*" -type d`.
-- **Jellyfin SDK pinning**: ALWAYS pin `Jellyfin.Controller` and `Jellyfin.Model` to MINIMUM supported minor version (e.g., `10.11.0`). NEVER use wildcards like `10.11.*`.
+- **Jellyfin SDK pinning**: ALWAYS pin `Jellyfin.Controller` and `Jellyfin.Model` to MINIMUM supported minor version (e.g., `12.0.0`). NEVER use wildcards like `12.0.*`. `Jellyfin.Data` is not referenced directly — it comes transitively via `Jellyfin.Model` — but the plugin uses `Jellyfin.Data.Enums` (`Api/SubtitleController.cs`, `Controller/MediaItemResolver.cs`, `ScheduledTasks/SubtitleGenerationTask.cs`), so a bump that breaks that transitive resolution would surface as a missing-namespace build error, not a silent runtime issue.
 
 ## Language Detection
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <a href="https://github.com/GeiserX/whisper-subs/releases"><img src="https://img.shields.io/github/v/release/GeiserX/whisper-subs?style=flat-square&logo=github&color=6B4C9A" alt="Release"></a>
   <a href="https://github.com/GeiserX/whisper-subs/actions/workflows/build-release.yml"><img src="https://img.shields.io/github/actions/workflow/status/GeiserX/whisper-subs/build-release.yml?branch=main&style=flat-square&label=tests" alt="Tests"></a>
   <a href="https://github.com/GeiserX/whisper-subs/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square" alt="License"></a>
-  <img src="https://img.shields.io/badge/.NET-9.0-512BD4?style=flat-square&logo=dotnet&logoColor=white" alt=".NET 9.0">
-  <img src="https://img.shields.io/badge/Jellyfin-10.11%2B-6B4C9A?style=flat-square" alt="Jellyfin 10.11+">
+  <img src="https://img.shields.io/badge/.NET-10.0-512BD4?style=flat-square&logo=dotnet&logoColor=white" alt=".NET 10.0">
+  <img src="https://img.shields.io/badge/Jellyfin-12.0%2B-6B4C9A?style=flat-square" alt="Jellyfin 12.0+">
   <a href="https://github.com/awesome-jellyfin/awesome-jellyfin#readme"><img src="https://img.shields.io/badge/listed%20on-awesome--jellyfin-00a4dc?style=flat-square&logo=jellyfin&logoColor=white" alt="listed on awesome-jellyfin"></a>
   <a href="https://codecov.io/gh/GeiserX/whisper-subs"><img src="https://codecov.io/gh/GeiserX/whisper-subs/graph/badge.svg" alt="codecov"></a>
 </p>
@@ -38,7 +38,7 @@
 
 | Dependency | Details |
 |---|---|
-| **Jellyfin** | 10.11.0 or later |
+| **Jellyfin** | 12.0.0 or later (use WhisperSubs 4.8.0.0 for Jellyfin 10.11.x) |
 | **FFmpeg** | Bundled with Jellyfin (`/usr/lib/jellyfin-ffmpeg/ffmpeg`) or available in `PATH`. Used to extract audio from media files. |
 | **whisper.cpp** | The `whisper-cli` binary. **On Linux, the plugin can download this automatically** from the settings page. Otherwise, install manually -- see [Installing whisper.cpp](#installing-whispercpp). |
 | **Whisper Model** | A GGML model file. **The plugin can download models automatically** from the settings page, or download manually from [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp). |

--- a/WhisperSubs.Tests/WhisperSubs.Tests.csproj
+++ b/WhisperSubs.Tests/WhisperSubs.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.8.0.0</Version>
+    <Version>5.0.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.19" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 

Mechanical SDK/ABI bump to target Jellyfin 12.0 / .NET 10.0:

- `TargetFramework` `net9.0` -> `net10.0` (`WhisperSubs.csproj`, `WhisperSubs.Tests/WhisperSubs.Tests.csproj`)
- `Jellyfin.Controller` / `Jellyfin.Model` `10.11.0` -> `12.0.0`
- `Microsoft.Extensions.Http` `9.0.19` -> `10.0.11`
- CI (`ci.yml`) and release (`build-release.yml`) workflows: `dotnet-version` `9.0.x` -> `10.0.x`, release DLL copy path `net9.0` -> `net10.0`, `targetAbi` `10.11.0.0` -> `12.0.0.0` in both `meta.json` and `manifest.json` generation
- Version `4.8.0.0` -> `5.0.0.0` (breaking SDK/ABI change)
- `CLAUDE.md` / `README.md`: updated target version references; Prerequisites now reads "12.0.0 or later (use WhisperSubs 4.8.0.0 for Jellyfin 10.11.x)" — a hard cutover, not multi-version support

## Why

Jellyfin 12.0 (released 2026-09-07) drops the "10." version prefix and moves the server/SDK from net9.0 to net10.0; plugins built against the old SDK fail to load. WhisperSubs doesn't use any of the APIs called out as breaking in the 12.0 release notes (`ISearchEngine`, `IAuthenticationProvider.HasPassword`, `IItemRepository`, `IUserManager`, the `Jellyfin.Api` namespace reorg), so no code changes were needed beyond the SDK/ABI bump.

## Verification

This is real GitHub Actions CI on Linux runners, not a local claim:

- CI run on this exact commit, run on `sdvaletone/whisper-subs`: https://github.com/sdvaletone/whisper-subs/actions/runs/34423155023
  - `build` job: restore, build, and test **all succeeded** against the net10.0 / .NET 10 SDK toolchain — **1458/1458 tests passed**, 0 failures.
  - `web-js` job (browser JS parse-check): passed.
  - The job's overall status shows a red X only because of the final "Upload coverage to Codecov" step, which is unrelated to this change: this fork has no `CODECOV_TOKEN` secret registered and Codecov rejects the tokenless upload (`"Token required - not valid tokenless upload"`). The same failure occurs identically on this fork's unmodified `main` branch today (independent of any change in this PR) — see https://github.com/sdvaletone/whisper-subs/actions/runs/34356565349. It's a fork-infrastructure gap (no Codecov project registered for this fork), not something introduced by this change, and out of scope for this PR.

## Residual risk / manual step

Merging this PR alone does **not** update Jellyfin's plugin catalog. `build-release.yml` (which regenerates and publishes `manifest.json` to GitHub Pages) only runs on a push to `main` in this repo (or `workflow_dispatch`) as part of a *release*. A maintainer with push/release access to `GeiserX/whisper-subs` needs to cut a new tagged release after merging for the 12.0-targeted build to actually reach `https://geiserx.github.io/whisper-subs/manifest.json` and become installable from a 12.0 server's catalog.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Jellyfin 12.0+ and .NET 10.0.
  * Updated the plugin release version to 5.0.0.0.

* **Documentation**
  * Updated prerequisites, supported-version badges, and setup guidance.
  * Clarified that WhisperSubs 4.8.0.0 remains available for Jellyfin 10.11.x.

* **Chores**
  * Updated automated builds and tests to use the .NET 10 SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->