### PR TITLE
chore(release): 4.8.0.1

### DIFF
--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.8.0.0</Version>
+    <Version>4.8.0.1</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Cuts a release carrying the documentation site and the npm dependency fixes.

The plugin's runtime code has not changed since 4.8.0.0 — no `.cs` file was touched by #163, #164 or #166 — so this is a fix-level bump rather than a feature release.

## What publishing this actually tests

This is the first release to run through the rebuilt pipeline, so it is worth watching rather than assuming:

- `build-release.yml` no longer deploys to Pages and no longer holds `pages: write`.
- The catalog now ships as a release asset instead of being written straight to the site.
- `pages.yml` picks it up on `workflow_run` and publishes it alongside the documentation.

No previous release carries a `manifest.json` asset, so the catalog will seed from the committed copy on this run. That file was refreshed from the live site in #163, which is what makes this safe: before that it was pinned at 3.17.0.0 while production served 4.8.0.0.

Expected catalog after publishing: `4.8.0.1, 4.8.0.0, 4.7.0.1, 4.7.0.0, 4.6.0.1`.