### PR TITLE
ci: stop cancelling releases in flight

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,7 +59,8 @@ updates:
       # TypeScript 7 removed the `baseUrl` compiler option, and
       # @docusaurus/tsconfig still sets it, so `npm run typecheck` fails on
       # the inherited value no matter what this repo does. Drop this entry
-      # once @docusaurus/tsconfig stops shipping baseUrl.
+      # once @docusaurus/tsconfig stops shipping baseUrl, and remove the
+      # baseUrl in site/tsconfig.json at the same time - both have to go.
       - dependency-name: typescript
         update-types:
           - version-update:semver-major

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,13 @@ updates:
       - dependency-name: '@docusaurus/*'
         update-types:
           - version-update:semver-major
+      # TypeScript 7 removed the `baseUrl` compiler option, and
+      # @docusaurus/tsconfig still sets it, so `npm run typecheck` fails on
+      # the inherited value no matter what this repo does. Drop this entry
+      # once @docusaurus/tsconfig stops shipping baseUrl.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,9 +10,13 @@ on:
       - '.github/workflows/build-release.yml'
   workflow_dispatch:
 
+# Never cancel in progress. This job spans "GitHub Release created" through
+# "catalog attached", and a merge that touches any trigger path would otherwise
+# kill a release mid-publish. A queued duplicate is harmless: check-version
+# skips when the tag already exists.
 concurrency:
   group: build-release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -187,14 +187,38 @@ jobs:
 
       - name: Get version and check tag
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(grep -oP '(?<=<Version>)[^<]+' WhisperSubs.csproj)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
+
+          if ! git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # A tag is not proof the release finished. action-gh-release creates
+          # the tag before uploading, so a failure mid-upload leaves a release
+          # with no catalog attached - and skipping on the tag alone would make
+          # that permanent. Require the assets a release is not usable without.
+          ASSETS='[]'
+          for attempt in 1 2 3; do
+            if FETCHED=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+                           --jq '[.assets[].name]' 2>/dev/null); then
+              ASSETS="$FETCHED"
+              break
+            fi
+            sleep 5
+          done
+
+          if echo "$ASSETS" | jq -e --arg zip "WhisperSubs_${VERSION}.zip" \
+               'index("manifest.json") != null and index($zip) != null' > /dev/null 2>&1; then
             echo "should_release=false" >> $GITHUB_OUTPUT
-            echo "::notice::Tag v${VERSION} already exists — skipping release"
+            echo "::notice::Release v${VERSION} is complete — skipping"
           else
             echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "::warning::Tag v${VERSION} exists but required assets are missing — re-running to repair"
           fi
 
   # ── Build plugin + create release ──────────────────────────────────


### PR DESCRIPTION
Merging a routine dependency bump killed a release that was already running. `build-release.yml` had `cancel-in-progress: true`, and any merge touching `**/*.cs`, `**/*.csproj`, `**/*.sln` or the workflow itself starts a new run that cancels the old one.

That window is not a safe place to be cancelled. It spans GitHub Release creation through catalog attachment, so an unlucky cancel leaves a published release with no catalog entry, or a tag with no assets.

It happened today merging #170, a `Microsoft.Extensions.Http` patch bump, which cancelled the 4.8.0.1 run. Nothing was corrupted this time because the cancel arrived during the binary matrix, before the release was created: no tag, no release, no partial state. The next one might land later.

A queued duplicate run is harmless by comparison. `check-version` skips when the tag already exists, so the worst case is a run that does nothing.

## Also: ignore typescript majors

TypeScript 7 cannot build here. It removed the `baseUrl` compiler option, and `@docusaurus/tsconfig` still sets it:

```
tsconfig.json(7,5): error TS5102: Option 'baseUrl' has been removed.
```

Removing `baseUrl` from `site/tsconfig.json` does not help, because the error moves to the inherited value from the framework's own config. `@docusaurus/tsconfig@3.10.2` is the newest published version and still ships it, so there is nothing to upgrade into. Verified by checking out #169 and running it, not inferred.

The ignore names `typescript` alone rather than using a wildcard, and comes out as soon as Docusaurus drops `baseUrl`. #169 is closed with the same evidence.

Blast radius, for the record: `tsconfig.json` is not used by `docusaurus build`, and `npm run typecheck` is not run by any workflow or hook, so this was never going to break the site or CI either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - Duplicate release runs now wait for the active run to finish instead of canceling it, improving release reliability.

- **Maintenance**
  - Major TypeScript updates are temporarily excluded from automated dependency update proposals to preserve compatibility with the current project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->