### PR TITLE
fix: stop shipping a ROCm binary built for the runner's CPU

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/rocm-output/whisper-cli
-          key: whisper-1.8.4-rocm-6.1.2-v4
+          key: whisper-1.8.4-rocm-6.1.2-v5-avx2
 
       - name: Build whisper-cli with ROCm
         if: steps.cache-whisper-rocm.outputs.cache-hit != 'true'
@@ -161,6 +161,8 @@ jobs:
                 -DBUILD_SHARED_LIBS=OFF \
                 -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
                 -DGGML_HIP=ON \
+                -DGGML_NATIVE=OFF \
+                -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON \
                 -DCMAKE_C_COMPILER=hipcc \
                 -DCMAKE_CXX_COMPILER=hipcc &&
               cmake --build build --config Release -j$(nproc) &&

--- a/Setup/BinaryCatalog.cs
+++ b/Setup/BinaryCatalog.cs
@@ -36,7 +36,8 @@ namespace WhisperSubs.Setup
 
         /// <summary>
         /// Returns only the variants that have prebuilt binaries for the given platform.
-        /// CI builds: linux-x64 (cpu, cuda12, vulkan, rocm), linux-arm64 (cpu only).
+        /// CI builds: linux-x64 (cpu, noavx, cuda12, cuda12-noavx, vulkan, vulkan-noavx,
+        /// rocm), linux-arm64 (cpu, noavx).
         /// </summary>
         public static BinaryVariant[] GetAvailableVariants(string platform)
         {

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -899,8 +899,8 @@ namespace WhisperSubs.Setup
         /// </summary>
         internal static bool VariantRequiresAvx2(string variant) => variant switch
         {
-            "cpu" or "cuda12" or "vulkan" => true,
-            _ => false   // noavx, cuda12-noavx, vulkan-noavx, rocm, unknown
+            "cpu" or "cuda12" or "vulkan" or "rocm" => true,
+            _ => false   // noavx, cuda12-noavx, vulkan-noavx, unknown
         };
 
         /// <summary>

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -178,7 +178,7 @@ public class SetupServiceTests
     [InlineData("noavx", false)]
     [InlineData("cuda12-noavx", false)]
     [InlineData("vulkan-noavx", false)]
-    [InlineData("rocm", false)]
+    [InlineData("rocm", true)]   // AVX2-native like cpu/cuda12/vulkan; falls back to noavx
     [InlineData("unknown", false)]
     public void VariantRequiresAvx2_OnlyNonNoavxBuilds(string variant, bool requiresAvx)
     {

--- a/site/docs/choosing-a-variant.md
+++ b/site/docs/choosing-a-variant.md
@@ -20,7 +20,7 @@ Choose one your CPU cannot run and it dies immediately with **exit code 132** an
 | `vulkan-noavx` | Vulkan (Compatibility) | SSE4.2 | Vulkan | `libvulkan1`, a Vulkan driver |
 | `cuda12` | NVIDIA CUDA 12 | AVX2, FMA, F16C, BMI2 | CUDA 12 | `libgomp1`, NVIDIA driver and CUDA runtime |
 | `cuda12-noavx` | NVIDIA CUDA 12 (Compatibility) | SSE4.2 | CUDA 12 | NVIDIA driver and CUDA runtime |
-| `rocm` | AMD ROCm | not pinned, see below | ROCm / HIP | `libgomp1`, ROCm runtime |
+| `rocm` | AMD ROCm | AVX2, FMA, F16C, BMI2 | ROCm / HIP | `libgomp1`, ROCm runtime |
 
 Every build is statically linked, so none of them needs `libwhisper.so`.
 
@@ -36,11 +36,15 @@ If you have read anywhere that every variant requires `libgomp1`, that is wrong.
 
 Only `cpu` and `noavx` are published for ARM64 (Raspberry Pi 4 and 5, Apple silicon Linux VMs, ARM servers). AVX does not exist on ARM, so on those machines the two builds differ **only** in OpenMP: pick `noavx` if `libgomp1` is missing, `cpu` otherwise.
 
-### The ROCm caveat
+:::warning[ROCm users: re-download your binary]
+ROCm binaries published before 4.8.0.2 were built for the CI machine's own CPU, which emitted AVX-512. They crash with an illegal instruction on any CPU without it, which includes every AMD Zen 1 to 3 and every Intel consumer chip from 12th gen onward.
 
-`rocm` is the one variant whose CPU instruction baseline we do not pin at build time. It follows the build machine, which is an AVX2-class CPU. There is no `rocm-noavx` build, and the plugin's automatic AVX2 guard does not cover `rocm`.
+Updating the plugin does not replace a binary you already downloaded: the setup check only looks for a file on disk, it does not record which release produced it. If you use the `rocm` variant, open **Whisper Engine** on the settings page and download it again after updating.
+:::
 
-So if your CPU lacks AVX2 and your GPU is AMD, there is no GPU variant for you. Use `noavx` and transcribe on the CPU.
+### No ROCm compatibility build
+
+There is no `rocm-noavx` build. If your CPU lacks AVX2 and your GPU is AMD, there is no GPU variant for you: the plugin detects this and falls back to `noavx`, so transcription runs on the CPU.
 
 ## Check what your CPU supports
 


### PR DESCRIPTION
An AMD GPU user on an older CPU gets a crash that this plugin is specifically built to prevent. Two independent mistakes line up to cause it.

## The binary targets an undefined CPU

Every variant pins its instruction set explicitly. ROCm was the one exception:

```
cpu     -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON ...
cuda12  -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON ...
vulkan  -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON ...
rocm    -DGGML_HIP=ON -DCMAKE_C_COMPILER=hipcc -DCMAKE_CXX_COMPILER=hipcc
```

`GGML_NATIVE` defaults ON in ggml and appends `-march=native`, so the published `whisper-cli-linux-x64-rocm` was compiled for whatever CPU the GitHub runner happened to have that day, quite possibly including AVX-512.

## The safety net skipped it

`VariantRequiresAvx2` returned `false` for `rocm`, so the pre-flight check that catches AVX2 binaries on non-AVX2 CPUs never fired for it. The binary downloads, passes validation, then dies with SIGILL at transcription time with no useful message.

`README.md:176` states the plugin "detects missing AVX support and automatically uses the `noavx` (Compatibility) build instead, both when recommending a variant and as a download-time fallback." That was not true for ROCm.

## The fix

ROCm now builds against the same AVX2 baseline as the other GPU variants, and joins the guard. `GetFallbackVariant` already maps `rocm` to `noavx`, so an affected user degrades to a working CPU build rather than crashing. Losing GPU acceleration beats not running at all.

The ROCm cache key moves to `v5-avx2`. The flags change the artifact, and without a new key the cached `-march=native` binary would be restored straight over the fix.

## On the test

`SetupServiceTests.cs` asserted `[InlineData("rocm", false)]`. It was not missing coverage, it was asserting the bug, which is why nothing ever flagged this. Flipped to `true`. The companion case `[InlineData("rocm", "noavx")]` for the fallback chain already existed and needs no change.

Note that CI is the only place these tests can run: this machine has no .NET 9 runtime, and a root-level `dotnet test` exits 0 while running nothing at all, so a local green here would have meant nothing.

Worth a real ROCm user confirming after release, since this changes the flags of a published binary rather than just plugin code.

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ROCm compatibility checks on systems without AVX2 support.
  - Automatically falls back to a compatible non-AVX build instead of failing during transcription.

- **Performance**
  - Updated ROCm builds with optimized CPU instruction support for improved performance on compatible systems.

- **Documentation**
  - Updated available prebuilt variants for Linux x64 and ARM64.
  - Documented ROCm CPU requirements, compatibility limitations, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->