### PR TITLE
docs: cut the README to a front door and fix eleven wrong claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,656 +14,142 @@
 
 ---
 
-**WhisperSubs** is a Jellyfin plugin that automatically generates subtitles for your media library using local AI models. Transcription runs on hardware you control -- this Jellyfin server by default, plus any transcription workers you choose to add -- so your media stays on your own network and is never sent to a third-party cloud unless you deliberately configure one. Your media stays private.
+**WhisperSubs** is a Jellyfin plugin that generates subtitles for your media library with local AI models. Transcription runs on hardware you control: this Jellyfin server by default, plus any transcription workers you choose to add. Your media never reaches a third-party cloud unless you deliberately configure one.
+
+## Documentation
+
+Everything past this page lives at **[geiserx.github.io/whisper-subs](https://geiserx.github.io/whisper-subs/)**.
+
+| Page | What it covers |
+|---|---|
+| [Setup guide](https://geiserx.github.io/whisper-subs/docs/setup/) | Installing the engine and a model, container library requirements, GPU passthrough, vocal separation |
+| [Choosing a binary variant](https://geiserx.github.io/whisper-subs/choosing-a-variant/) | The seven prebuilt variants, which one your CPU and GPU can actually run, exit code 132 |
+| [Platform-specific installs](https://geiserx.github.io/whisper-subs/install-topologies/) | TrueNAS SCALE, Proxmox LXC, Synology DSM, unRAID, plain Docker Compose |
+| [Diagnostics](https://geiserx.github.io/whisper-subs/diagnostics/) | Reading the status and queue endpoints, API keys, what a useful bug report contains |
+| [Remote workers](https://geiserx.github.io/whisper-subs/remote-workers/) | The worker pool, the worker container, Groq / OpenAI / OpenRouter as a backend |
+| [Limitations](https://geiserx.github.io/whisper-subs/limitations/) | What it cannot do, and why |
 
 ## Features
 
-- **Self-Hosted Processing** -- Audio is transcribed on hardware you control using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) -- this server by default, or a pool of your own workers. No third-party cloud is involved unless you deliberately add a cloud worker.
-- **Built-in Engine Setup** -- Download whisper-cli binaries and models directly from the plugin settings page on Linux. No manual installation needed for most users.
-- **Automatic Language Detection** -- Reads audio stream metadata to detect the spoken language and generate matching subtitles. Falls back to whisper's built-in language detection when tags are absent.
-- **Forced Subtitles** -- Detect and transcribe only foreign-language dialogue (e.g., French lines in an English movie) via VAD-based speech segmentation and per-chunk language detection.
-- **Lyrics Generation (Experimental)** -- Generate `.lrc` lyrics files for music libraries via whisper transcription. Jellyfin picks up `.lrc` files automatically.
-- **Vocal Separation (Optional)** -- Isolate vocals from background noise and music using [BSRoformer.cpp](https://github.com/chenmozhijin/BSRoformer.cpp) before transcription for improved accuracy on noisy content. Fails gracefully and falls back to original audio if unavailable.
-- **GPU Acceleration** -- Supports CUDA (NVIDIA), Vulkan (Intel / AMD / NVIDIA), and ROCm (AMD) for significantly faster transcription.
-- **Distributed Transcription (Worker Pool)** -- Optionally pool several machines, GPUs, a NAS, or a cloud endpoint and transcribe your backlog in parallel across all of them. Additive and off by default: with no workers configured, everything runs on this server exactly as before, and the plugin always prefers your free local workers before bursting to a paid one. See [`worker/`](worker/README.md) for a ready-to-run worker image.
-- **Priority Queue** -- Manual requests are queued with priority and processed before scheduled items. Queue persists across restarts.
-- **Real-time Progress** -- Live progress banner in the admin UI showing current item, phase (extracting audio, transcribing), per-file progress, and overall stats.
-- **Subtitle Resume** -- If transcription is interrupted, it resumes from the last timestamp rather than starting over.
-- **Admin Dashboard UI** -- Browse libraries, view items, manage the whisper engine, and trigger subtitle generation directly from the Jellyfin admin panel.
-- **Scheduled Tasks** -- Enable automatic scanning so new media gets subtitles without manual intervention. Runs daily at 2:00 AM and on startup by default. On large libraries, repeat runs are fast: a **skip cache** remembers which items already have subtitles and skips re-checking unchanged files, re-checking an item only when Jellyfin re-saves it or you change a skip setting (configurable, on by default; a "Clear skip cache" button forces a full re-check).
-- **Per-Library Control** -- Choose which libraries are monitored for automatic subtitle generation.
-- **Multiple Output Formats** -- Generates `.srt` subtitles, `.forced.generated.srt` forced subtitles, and `.lrc` lyrics, all placed alongside your media and auto-detected by Jellyfin.
+- **Self-hosted processing.** Audio is transcribed by [whisper.cpp](https://github.com/ggerganov/whisper.cpp) on this server by default, or across a pool of your own workers.
+- **Built-in engine setup.** The settings page downloads the `whisper-cli` binary and a model. Binary downloads are **Linux only**: on macOS and Windows the variant dropdown is empty by design, and you install `whisper-cli` yourself and set **Whisper Binary Path**. Model downloads work on every platform.
+- **Automatic language detection.** Reads each audio stream's language tag, falling back to whisper's own detection when tags are absent. A multi-language file gets one subtitle per audio language.
+- **Forced subtitles.** Transcribe only foreign-language dialogue, via VAD speech segmentation and per-chunk language detection.
+- **English translation.** Optionally add an English subtitle to a title that has none. English is the only language whisper can translate into.
+- **Lyrics (experimental).** `.lrc` files for music libraries, picked up by Jellyfin automatically.
+- **Vocal separation (optional).** Isolate vocals with [BSRoformer.cpp](https://github.com/chenmozhijin/BSRoformer.cpp) before transcription for noisy content. Falls back to the original audio when unavailable.
+- **GPU acceleration.** CUDA (NVIDIA), Vulkan (Intel / AMD / NVIDIA) and ROCm (AMD).
+- **Distributed transcription.** Pool extra machines, GPUs, a NAS or a hosted endpoint and transcribe in parallel. Off by default, and free local workers are always used before bursting to a paid one.
+- **Priority queue with user requests.** Manual requests outrank the background sweep. Non-admin users can request subtitles from the item menu once you enable it.
+- **Real-time progress.** A live banner shows the current item, the phase, per-file progress and queue depth.
+- **Subtitle resume.** An interrupted transcription continues from its last timestamp instead of starting over.
+- **Admin dashboard.** Browse libraries, see which items have subtitles, and generate them from the Jellyfin admin panel or from an in-page button on the item page.
+- **Scheduled task with a skip cache.** Daily at 2:00 AM and on startup by default. A persistent skip cache means repeat runs do not re-probe unchanged items.
+- **Configurable output filenames.** The label and filename template are yours to change.
 
 ## Prerequisites
 
 | Dependency | Details |
 |---|---|
 | **Jellyfin** | 10.11.0 or later |
-| **FFmpeg** | Bundled with Jellyfin (`/usr/lib/jellyfin-ffmpeg/ffmpeg`) or available in `PATH`. Used to extract audio from media files. |
-| **whisper.cpp** | The `whisper-cli` binary. **On Linux, the plugin can download this automatically** from the settings page. Otherwise, install manually -- see [Installing whisper.cpp](#installing-whispercpp). |
-| **Whisper Model** | A GGML model file. **The plugin can download models automatically** from the settings page, or download manually from [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp). |
-| **BSRoformer.cpp** (Optional) | The `bs_roformer-cli` binary for vocal separation. The plugin can download a pinned build automatically on supported Linux, macOS, and Windows systems. Optional — vocal separation improves transcription on noisy audio but is not required. |
-
-> **Quick start:** After installing the plugin, go to **Dashboard** > **Plugins** > **WhisperSubs**. On Linux, the **Whisper Engine** section lets you download the whisper-cli binary and model with one click each. On supported Linux, macOS, and Windows systems, the optional **Vocal Separation** section can download the bs_roformer-cli binary and model for improved transcription on noisy content. The manual steps below are only needed on unsupported platforms or for custom installations.
+| **FFmpeg** | Bundled with Jellyfin (`/usr/lib/jellyfin-ffmpeg/ffmpeg`) or on `PATH`. Used to extract audio. |
+| **whisper.cpp** | The `whisper-cli` binary. Downloadable from the settings page on Linux; installed manually on macOS and Windows. See the [setup guide](https://geiserx.github.io/whisper-subs/docs/setup/). |
+| **Whisper model** | A GGML model file, downloadable from the settings page on every platform, or manually from [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp). |
+| **BSRoformer.cpp** *(optional)* | The `bs_roformer-cli` binary for vocal separation. Downloadable from the settings page on Linux, macOS and Windows. |
 
 ## Installation
 
-### From the Jellyfin Plugin Repository (Recommended)
+### From the Jellyfin plugin repository (recommended)
 
 1. In Jellyfin, go to **Dashboard** > **Plugins** > **Repositories**.
-2. Add a new repository with this URL:
+2. Add a repository with this URL:
    ```
    https://geiserx.github.io/whisper-subs/manifest.json
    ```
 3. Go to **Catalog**, find **WhisperSubs**, and click **Install**.
 4. Restart Jellyfin.
 
-### Manual Installation
+Then open **Dashboard** > **Plugins** > **WhisperSubs** and follow the [setup guide](https://geiserx.github.io/whisper-subs/docs/setup/) to install the engine and a model.
 
-1. Build from source:
-   ```bash
-   dotnet build --configuration Release
-   ```
-2. Copy `WhisperSubs.dll` to your Jellyfin plugins directory:
-   ```
-   /var/lib/jellyfin/plugins/WhisperSubs/
-   ```
-3. Restart Jellyfin.
-
-## Installing whisper.cpp
-
-The plugin requires whisper.cpp for transcription. Choose the method that matches your setup.
-
-### Option A: Pre-built Binary (Recommended for most users)
-
-1. Download the latest release for your platform from [whisper.cpp releases](https://github.com/ggerganov/whisper.cpp/releases).
-2. Extract and place the `whisper-cli` binary somewhere persistent (e.g., `/opt/whisper/`).
-3. Download a model:
-   ```bash
-   mkdir -p /opt/whisper/models
-
-   # Base model (~148 MB) -- fast, good for quick transcription
-   wget -O /opt/whisper/models/ggml-base.bin \
-     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
-
-   # Large V3 Turbo (~1.6 GB) -- best accuracy with reasonable speed (recommended)
-   wget -O /opt/whisper/models/ggml-large-v3-turbo.bin \
-     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin
-   ```
-4. In the plugin settings, set **Whisper Binary Path** to `/opt/whisper/whisper-cli` and **Whisper Model Path** to the model file.
-
-### Option B: Build from Source (CPU only)
+### Manual installation
 
 ```bash
-git clone https://github.com/ggerganov/whisper.cpp.git
-cd whisper.cpp
-cmake -B build -DBUILD_SHARED_LIBS=OFF
-cmake --build build --config Release -j$(nproc)
-# Binary will be at build/bin/whisper-cli
+dotnet build --configuration Release
+# copy WhisperSubs.dll to /var/lib/jellyfin/plugins/WhisperSubs/, then restart Jellyfin
 ```
 
-### Option C: Build from Source with GPU Acceleration
+## Output files
 
-See [GPU Acceleration](#gpu-acceleration) below for detailed instructions.
+Subtitles are written next to the media and picked up by Jellyfin on the metadata refresh that follows. The default filename template is `{name}.{lang}.{label}{.type}` with the label `WhisperSubs`, so a Spanish film produces:
 
-### Docker / Container Setups
-
-If Jellyfin runs in a Docker container, whisper.cpp must be accessible **inside** the container. The recommended approach is to bind-mount a host directory containing the binary and model:
-
-```yaml
-# docker-compose.yml
-services:
-  jellyfin:
-    image: jellyfin/jellyfin
-    volumes:
-      - /opt/whisper:/opt/whisper:ro   # whisper-cli binary + models
-      # ... your other volumes
-```
-
-Then configure the plugin with:
-- **Whisper Binary Path**: `/opt/whisper/whisper-cli`
-- **Whisper Model Path**: `/opt/whisper/models/ggml-large-v3-turbo.bin`
-
-> **Note:** The binary must be compiled for the same architecture as the container (typically x86_64 Linux). Download the `linux-x64` release asset or build inside a matching environment.
-
-#### In-Page "Generate Subtitles" Button
-
-The plugin adds an in-page "Generate Subtitles" button/menu to the Jellyfin web UI. This appears on media detail pages and lets you trigger transcription directly from your browser. Internally, the plugin injects a script tag into Jellyfin's `index.html` to register this UI.
-
-By default, the plugin attempts **direct on-disk injection** — writing the script tag directly to the index.html file. This requires write access to Jellyfin's web root, which is often read-only in containerized setups. If your web root is read-only (common in Docker), you have two options:
-
-**Option A: Use File Transformation (Recommended for read-only roots)**
-
-Install the third-party **File Transformation** plugin by IAmParadox27. This plugin allows whisper-subs to inject the script at serve-time, without modifying the index.html file on disk:
-
-1. In Jellyfin, go to **Dashboard** > **Plugins** > **Repositories**.
-2. Add this repository URL:
-   ```
-   https://www.iamparadox.dev/jellyfin/plugins/manifest.json
-   ```
-3. Go to **Catalog**, find **File Transformation**, and click **Install**.
-4. Restart Jellyfin.
-5. Open the **WhisperSubs** plugin settings page — the *In-page "Generate Subtitles" button & menu* status panel at the top shows the active mechanism (it should now include **File Transformation (serve-time)**).
-
-No permission changes or `chown`/`chmod` are needed. Both direct injection and File Transformation coexist safely — if both are available, both mechanisms activate and work together without duplication.
-
-**Option B: Make index.html writable (if you manage the web root)**
-
-The status panel on the WhisperSubs settings page shows the exact `index.html` path it detected. Make that file writable by the Jellyfin service user, then click **Re-inject**:
-
-```bash
-# Linux package install (use the path shown in the status panel):
-sudo chown root:jellyfin /usr/share/jellyfin/web/index.html
-sudo chmod 664 /usr/share/jellyfin/web/index.html
-```
-
-On Docker the user/group differ (e.g. linuxserver.io images use your `PUID`/`PGID`), and a read-only web mount must be made writable in your compose file before the direct on-disk injection can work.
-
-#### <a id="container-setup"></a>Container Library Requirements
-
-The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. These require runtime libraries that are **not included** in the default Jellyfin Docker image:
-
-| Variant | Required packages | Install command |
-|---------|-------------------|-----------------|
-| **CPU** | `libgomp1` | `apt install libgomp1` |
-| **CPU (Compatibility)** | none (self-contained) | — |
-| **Vulkan** | `libgomp1`, `libvulkan1`, `mesa-vulkan-drivers` | `apt install libgomp1 libvulkan1 mesa-vulkan-drivers` |
-| **CUDA 12** | `libgomp1` + NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
-| **ROCm** | `libgomp1` + ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
-
-> **Minimal containers (TrueNAS Scale, slim Docker):** The default `cpu` build links `libgomp1` (OpenMP) for best performance. If that library is missing, **the plugin automatically falls back to the `noavx` build**, which is compiled with OpenMP off and has no such dependency — so transcription still works out of the box, just without the small OpenMP speed-up.
-
-> **Older / low-power CPUs (no AVX):** The `cpu`, `vulkan` and `cuda12` builds are compiled with AVX/AVX2 instructions and will crash with an *illegal instruction* error (exit 132) on CPUs that lack them — common on budget NAS boxes, Atom/Celeron chips and some VMs. The plugin **detects missing AVX support and automatically uses the `noavx` (Compatibility) build** instead, both when recommending a variant and as a download-time fallback. You can also pick **"CPU (Compatibility)"** manually on the setup page.
-
-For the faster build, install `libgomp1` persistently via your container's entrypoint or Dockerfile:
-
-```bash
-apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
-```
-
-The plugin's setup page will detect missing libraries and warn you before downloading.
-
-### Verifying the Installation
-
-```bash
-# If in PATH:
-whisper-cli --help
-
-# If using an absolute path:
-/opt/whisper/whisper-cli --help
-
-# Inside a Docker container:
-docker exec jellyfin /opt/whisper/whisper-cli --help
-```
-
-## GPU Acceleration
-
-whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA GPUs), **CUDA** (NVIDIA), and **ROCm** (AMD). GPU acceleration dramatically reduces transcription time, especially with larger models.
-
-> **Offloading to another machine?** You can run transcription on a separate host as an OpenAI-compatible worker and point the plugin at it over HTTP — see [`worker/`](worker/README.md) for a ready-to-run whisper.cpp + Vulkan worker image (plus notes for CPU/NVIDIA/AMD backends).
-
-> **Docker users:** Passing the GPU device (e.g., `/dev/dri`) to a container is **not enough** -- the container also needs the matching userspace libraries installed. The auto-setup wizard detects both the device and the library and will fall back to CPU if the library is missing.
->
-> | Backend | Device | Required library | Install command (Debian/Ubuntu) |
-> |---------|--------|------------------|---------------------------------|
-> | **CUDA** | `/dev/nvidia0` | `libcuda.so.1` | `nvidia-container-toolkit` (host) |
-> | **Vulkan** | `/dev/dri` | `libvulkan.so.1` + ICD JSON | `apt install libvulkan1 mesa-vulkan-drivers` (also needs `/usr/share/vulkan/icd.d/*.json`) |
-> | **ROCm** | `/dev/kfd` | `libamdhip64.so` | `apt install rocm-hip-runtime` |
-
-### Vulkan (Intel / AMD)
-
-Vulkan is the best option for Intel iGPUs (e.g., UHD 770) and AMD GPUs. It works through the Mesa Vulkan drivers.
-
-#### Building whisper.cpp with Vulkan
-
-```bash
-git clone https://github.com/ggerganov/whisper.cpp.git
-cd whisper.cpp
-cmake -B build \
-  -DGGML_VULKAN=ON \
-  -DBUILD_SHARED_LIBS=OFF
-cmake --build build --config Release -j$(nproc)
-# Binary: build/bin/whisper-cli
-```
-
-> **Important:** The CMake flag is `-DGGML_VULKAN=ON` (not `-DWHISPER_VULKAN`). This is a common source of confusion.
-
-#### Runtime Dependencies
-
-The Vulkan binary requires these libraries at runtime:
-
-| Package (Debian/Ubuntu) | Purpose |
+| Kind | File |
 |---|---|
-| `libvulkan1` | Vulkan loader |
-| `mesa-vulkan-drivers` | Intel (ANV) and AMD (RADV) Vulkan ICDs |
-| `libgomp1` | OpenMP threading |
+| Full subtitles | `Movie.es.WhisperSubs.srt` |
+| Forced subtitles | `Movie.es.WhisperSubs.forced.srt` |
+| English translation | `Movie.en.WhisperSubs.translated.srt` |
+| Lyrics | `Song.lrc` |
 
-```bash
-apt-get install -y libvulkan1 mesa-vulkan-drivers libgomp1
-```
+The label is both the title shown in Jellyfin's subtitle picker and the marker the plugin uses to recognise its own files, so pick something distinctive if you change it. Files written by older versions with the `.generated.` anchor are still recognised. Both **Subtitle label** and **Filename template** are on the settings page.
 
-#### Docker: GPU Passthrough for Vulkan
+## Subtitle modes
 
-To use an Intel or AMD GPU inside a Docker container:
+| Mode | What it generates |
+|---|---|
+| **Full** (default) | Complete transcription of all speech |
+| **Forced only** | Foreign-language dialogue only. Slow: a 2-hour film needs roughly 240 language-detection calls before transcription starts. |
+| **Full + forced** | Both, per audio track |
+| **Translation only** | An English translated subtitle, skipping native-language transcription |
 
-```yaml
-services:
-  jellyfin:
-    image: jellyfin/jellyfin
-    devices:
-      - /dev/dri:/dev/dri    # GPU render nodes
-    volumes:
-      - /opt/whisper:/opt/whisper:ro
-```
+The scheduled task skips media that already has a usable subtitle in the needed language. Forced and image-based tracks do not satisfy that need unless you turn on **Count image-based subtitles as present**. A manual **Generate** on a single item always transcribes, bypassing the skip.
 
-The container also needs the Vulkan runtime libraries. If using the official Jellyfin image (Debian-based), install them on startup:
+## User subtitle requests
 
-```yaml
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        dpkg -s libvulkan1 > /dev/null 2>&1 || \
-          (apt-get update -qq && \
-           apt-get install -y -qq --no-install-recommends \
-             libvulkan1 mesa-vulkan-drivers libgomp1 > /dev/null 2>&1 && \
-           rm -rf /var/lib/apt/lists/*)
-        exec /jellyfin/jellyfin
-```
+Off by default. Turn on **Allow user requests** in the **User Requests** panel and non-admin users get a **Request Subtitles** entry on the item page. Requests land as Pending and cost no CPU until an admin approves them, unless you also turn on **Auto-approve**. Approved requests enter the queue below admin requests and above the background sweep. Per-user daily quota (5), active cap (3), per-request item cap (200) and a global cap (500) are all configurable, and `0` means unlimited.
 
-Verify GPU detection inside the container:
+## Models
 
-```bash
-# Should show your GPU (e.g., "Intel(R) UHD Graphics 770")
-docker exec jellyfin apt-get update -qq && \
-  docker exec jellyfin apt-get install -y -qq vulkan-tools && \
-  docker exec jellyfin vulkaninfo --summary
-```
+Nine models are offered on the settings page. The default is **Large V3 Turbo (Q5)**, 574 MB.
 
-#### Building Inside Docker (ABI Compatibility)
-
-When Jellyfin runs in a container, the whisper binary must be compiled against matching system libraries. Build inside a container with the same base image:
-
-```bash
-# On the Docker host:
-docker run --rm -v /opt/whisper:/output debian:trixie bash -c '
-  apt-get update && apt-get install -y git cmake g++ libvulkan-dev &&
-  git clone https://github.com/ggerganov/whisper.cpp.git /tmp/whisper &&
-  cd /tmp/whisper &&
-  cmake -B build -DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF &&
-  cmake --build build --config Release -j$(nproc) &&
-  cp build/bin/whisper-cli /output/whisper-cli
-'
-```
-
-### CUDA (NVIDIA)
-
-For NVIDIA GPUs with CUDA support:
-
-#### Building whisper.cpp with CUDA
-
-```bash
-git clone https://github.com/ggerganov/whisper.cpp.git
-cd whisper.cpp
-cmake -B build \
-  -DGGML_CUDA=ON \
-  -DBUILD_SHARED_LIBS=OFF
-cmake --build build --config Release -j$(nproc)
-```
-
-#### Docker: NVIDIA GPU Passthrough
-
-```yaml
-services:
-  jellyfin:
-    image: jellyfin/jellyfin
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-    volumes:
-      - /opt/whisper:/opt/whisper:ro
-```
-
-> Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
-
-### Verifying GPU Acceleration
-
-After configuring GPU support, trigger a transcription and check the Jellyfin logs. You should see:
-
-```
-# Vulkan
-whisper_backend_init_gpu: using Vulkan0 backend
-
-# CUDA
-whisper_backend_init_gpu: using CUDA0 backend
-```
-
-If you see `no GPU found` or `using CPU backend`, the binary was not built with GPU support or the runtime drivers are missing.
-
-### Model Recommendations
-
-| Model | Size | Speed (CPU) | Speed (GPU) | Quality | Use Case |
-|---|---|---|---|---|---|
-| `ggml-large-v3-turbo-q5_0.bin` | 574 MB | Moderate | Fast | Excellent | **Recommended.** Best quality/size ratio. |
-| `ggml-large-v3-turbo.bin` | 1.6 GB | Slow | Fast | Excellent | Full-precision turbo. Slightly better quality, 3x larger. |
-| `ggml-medium-q5_0.bin` | 539 MB | Moderate | Fast | Very good | Similar size to turbo-q5 but slower and less accurate. |
-| `ggml-medium.bin` | 1.5 GB | Moderate | Fast | Very good | Full-precision medium model. |
-| `ggml-small.bin` | 488 MB | Fast | Very fast | Good | Faster inference, lower accuracy. |
-| `ggml-base.bin` | 148 MB | Fast | Very fast | Fair | Lightweight. Fast but noticeably less accurate. |
-| `ggml-tiny.bin` | 78 MB | Very fast | Very fast | Basic | Smallest model. Only for testing or constrained environments. |
-
-The Q5 quantized models offer nearly identical quality to their F16 counterparts at a fraction of the size. `ggml-large-v3-turbo-q5_0` is the default when downloading from the plugin settings page.
-
-## Distributed Transcription (Worker Pool)
-
-By default WhisperSubs transcribes on this Jellyfin server, one job at a time. If you have more than one machine -- a second box with a GPU, a NAS, or a cloud endpoint -- you can pool them and transcribe your backlog **in parallel**.
-
-This is entirely optional and off by default. With no workers configured, nothing changes: the plugin runs exactly as before, on this server. When you add workers, the plugin still extracts audio locally and then farms transcription out over HTTP to any OpenAI-compatible Whisper endpoint you point it at. It always prefers your **free local** workers and only "bursts" to a worker with a non-zero **cost weight** when the local ones are all busy.
-
-**Set it up in the plugin settings:**
-
-1. Open **Dashboard** > **Plugins** > **WhisperSubs** and expand **Worker Pool (Optional / Advanced)**.
-2. Leave **Also use this server as a worker** on to keep transcribing here too, or turn it off to offload entirely (e.g. a weak NAS handing all work to a beefier box).
-3. Click **+ Add worker** for each endpoint. Give it an endpoint URL (base URL, no `/v1` suffix), an optional API key/model, a **max concurrency** (keep `1` per single GPU), and a **cost weight** (`0` = free/local, preferred; `>0` = only used to burst).
-4. Use each row's **Test** button (`POST /Workers/TestConnection`) to confirm the endpoint is reachable and transcribes before saving.
-
-The live queue view shows which worker is transcribing which item, so you can see the pool working.
-
-> **Need a worker to point at?** [`worker/`](worker/README.md) is a ready-to-run whisper.cpp + Vulkan worker image (with notes for CPU/NVIDIA/AMD backends). Any server that implements the OpenAI `/v1/audio/transcriptions` and `/v1/audio/translations` endpoints -- e.g. [Speaches](https://github.com/speaches-ai/speaches) -- also works.
-
-### Hosted providers: upload size, base URLs and model names
-
-WhisperSubs extracts 16 kHz mono PCM WAV, which is **1.92 MB per minute** of audio. That matters as soon as you point a worker at a hosted API:
-
-| Audio length | WAV (default) | FLAC | Opus 24k |
+| Model | Size | Translates | Notes |
 |---|---|---|---|
-| 13 minutes | ~25 MB | ~13 MB | ~2 MB |
-| 40 minutes | 76.8 MB | ~39 MB | ~7 MB |
-| 2 hours | 219.7 MB | ~116 MB | ~20 MB |
+| `ggml-large-v3-turbo-q5_0.bin` | 574 MB | no | Default. Best quality/size ratio. |
+| `ggml-large-v3-turbo.bin` | 1620 MB | no | Full-precision turbo. |
+| `ggml-large-v3-q5_0.bin` | 1081 MB | yes | Best choice for non-English audio and translation. |
+| `ggml-large-v3.bin` | 3095 MB | yes | Maximum accuracy, 3-4x slower than turbo, ~4 GB RAM. |
+| `ggml-medium-q5_0.bin` | 539 MB | yes | Similar size to turbo-q5, slower and less accurate. |
+| `ggml-medium.bin` | 1530 MB | yes | Full-precision medium. |
+| `ggml-small.bin` | 488 MB | yes | Faster, lower accuracy. |
+| `ggml-base.bin` | 148 MB | yes | Lightweight. |
+| `ggml-tiny.bin` | 78 MB | yes | Testing and constrained environments only. |
 
-So a 25 MB cap (OpenAI, and Groq's free tier) accepts only about **13 minutes** of the default WAV upload, and rejects anything longer with `HTTP 413`. Two per-worker settings fix that:
+**The two turbo models cannot translate.** They were fine-tuned without the translate task, so enabling translation with one of them writes the *source* language into an English-named `.translated.srt` file. The plugin logs a warning and runs the job anyway; nothing in the filename or the subtitle picker reveals it. Download **Large V3 (Q5)** or **Medium (Q5)** before turning translation on. [Limitations](https://geiserx.github.io/whisper-subs/limitations/) has the detail.
 
-- **Max upload size (MB)** -- what this endpoint accepts. `0` (default) means unlimited, which is right for every self-hosted worker. Set it (25 for OpenAI and for Groq on **both** tiers -- Groq's 100 MB figure applies only to their `url` parameter, which WhisperSubs does not use) and an oversized title fails immediately with a message telling you the size, the cap and roughly how many minutes fit -- instead of uploading the whole file to earn a bare 413.
-- **Upload format** -- `WAV` (default), `FLAC` (lossless, about half) or `Opus 24k` (about a tenth; a 2-hour film lands near 20 MB). **Keep WAV for self-hosted workers**: whisper.cpp's `whisper-server` decodes WAV only, and the [`worker/`](worker/README.md) image ships without ffmpeg. Only choose a compressed format on a hosted endpoint documented to accept it (Groq accepts FLAC and OGG and explicitly recommends FLAC for size reduction; OpenAI's documented list is mp3/mp4/mpeg/mpga/m4a/wav/webm).
+## Distributed transcription
 
-**Base URL form** -- enter only the base; WhisperSubs appends `/v1/audio/transcriptions` itself, so the URL must **not** already end in `/v1`:
+By default everything runs on this Jellyfin server, one job at a time. Expand **Worker Pool (Optional / Advanced)** to add OpenAI-compatible endpoints: another box with a GPU, a NAS, or a hosted API. The plugin extracts audio locally and sends it over HTTP, always preferring workers with a cost weight of `0` and bursting to a paid one only when the free ones are saturated. [`worker/`](worker/README.md) is a ready-to-run whisper.cpp + Vulkan worker image. Setup, upload-size caps and provider quirks are covered in [Remote workers](https://geiserx.github.io/whisper-subs/remote-workers/).
 
-| Provider | Enter this |
-|---|---|
-| Groq | `https://api.groq.com/openai` |
-| OpenRouter | `https://openrouter.ai/api` |
-| OpenAI | `https://api.openai.com` |
+## Settings
 
-**Model names and provider limitations:**
+Every setting on **Dashboard** > **Plugins** > **WhisperSubs** carries its own inline help. Six tunables are deliberately not on that page and can only be changed in the plugin's XML configuration file, followed by a Jellyfin restart:
 
-- **OpenRouter** requires a namespaced slug (`openai/whisper-large-v3-turbo`, not `whisper-1`); a bare name returns `400`. It also rejects `response_format=srt` outright -- WhisperSubs negotiates to timestamped JSON automatically -- and has **no `/v1/audio/translations` endpoint**, so turn **Can translate** off for it. Timestamps are only available on its OpenAI-compatible models; models that return text without timings cannot produce synchronized subtitles.
-- **OpenAI**: timestamps and SRT are available on `whisper-1` only. `gpt-4o-transcribe` / `gpt-4o-mini-transcribe` return `json`/`text` with no timings, so they cannot be used for subtitles.
-- Turn off **Can translate** for any provider that does not expose `/v1/audio/translations`.
-
-> **Note:** the automatic scheduled sweep currently processes its backlog one item at a time; manual **Generate** / **Generate All** already fan out across the whole pool. Parallelizing the scheduled sweep is on the [roadmap](ROADMAP.md).
-
-## Configuration
-
-After installation, navigate to **Dashboard** > **Plugins** > **WhisperSubs** to configure:
-
-| Setting | Description |
-|---|---|
-| **Default Language** | `Auto-detect` reads the language from each file's audio stream metadata and generates matching subtitles. Choose a specific language to force it for all transcriptions. |
-| **Audio Languages (auto-detect)** (`AudioLanguageSelection`) | Only applies with **Auto-detect** on a file that has more than one audio language. `All audio languages` (default) transcribes **every** audio track's language -- one `.<lang>.generated.srt` per language. `Primary audio track only` transcribes just the first/primary track and skips the others. A specific default language, or a file with no audio language tags, is unaffected. |
-| **Subtitle Mode** | Full, Forced Only, Full + Forced, or Translation Only. See [Subtitle Modes](#subtitle-modes) below. |
-| **Enable Auto-Generation** | When enabled, the scheduled task will scan selected libraries and generate subtitles for items that lack them. |
-| **Enabled Libraries** | Select which libraries should be monitored for automatic subtitle generation. |
-| **Enable Lyrics Generation** | When enabled, music libraries are scanned and audio tracks receive `.lrc` lyrics files (experimental -- whisper is optimized for speech, not singing). |
-| **Whisper Binary Path** | *(Advanced)* Absolute path to the `whisper-cli` binary. Leave empty to use the auto-downloaded binary or search `PATH`. |
-| **Whisper Model Path** | *(Advanced)* Absolute path to the GGML model file. Leave empty to use the auto-downloaded model. |
-| **Whisper Thread Count** | *(Advanced)* Number of CPU threads for whisper inference. `0` = whisper default (4). Set to your CPU core count for faster transcription. |
-| **Maximum subtitle line length** (`SubtitleMaxLineLength`) | *(Advanced)* Maximum characters per subtitle cue, passed to `whisper-cli` as `--max-len` together with `--split-on-word` so a cap never breaks mid-word. `0` (default) = unlimited, which is whisper.cpp's own default, so existing installs are unchanged. **Raise this if subtitles arrive as one long run-on line** -- whisper applies no cap of its own, so a stretch it fails to punctuate lands in a single enormous cue. Broadcast subtitling caps a line near 42 characters; `47` is a good starting point. Applies to the local `whisper-cli` only -- a remote worker segments its own output, so set `WHISPER_MAX_LEN` on the worker as well (see [the worker README](worker/README.md)). |
-| **Also use this server as a worker** (`EnableLocalWorker`) | *(Worker Pool)* Whether this Jellyfin host's own whisper participates in the pool. On by default. Turn it off to transcribe **only** on the remote workers below -- e.g. a weak NAS offloading entirely to a beefier box. |
-| **Workers** | *(Worker Pool)* A list of extra OpenAI-compatible transcription endpoints to pool alongside (or instead of) this server. Empty by default. Each row has an endpoint URL, optional API key, optional model, max concurrency, cost weight, **max upload size** (`0` = unlimited), **upload format** (`wav` default / `flac` / `opus`), and a "can translate" flag. WhisperSubs preserves direct SRT for existing servers; if an endpoint rejects SRT, it negotiates once to timestamped `verbose_json` segments (supported by Groq, OpenRouter-compatible providers, and OpenAI `whisper-1`), converts them to SRT, and caches that choice. Text-only JSON models cannot produce synchronized subtitles because they return no timestamps. See [Distributed Transcription](#distributed-transcription-worker-pool). |
-| **Job timeout -- real-time factor** (`JobTimeoutRealtimeFactor`) | *(Advanced)* Upper bound on how much slower than real-time a remote worker may run before a single call is presumed hung and cancelled. Per-call deadline = audio length x this factor (clamped by the min/max below). Default `6`. A slow-but-working pass is never cut off; a dead endpoint is. |
-| **Job timeout -- minimum seconds** (`JobMinTimeoutSeconds`) | *(Advanced)* Floor for the per-call deadline, so a tiny detection clip still gets a sane minimum. Default `60`. |
-| **Job timeout -- maximum hours** (`JobMaxTimeoutHours`) | *(Advanced)* Absolute cap for the per-call deadline; a genuinely long film's worst case still fits under it. Default `12`. |
-
-### Subtitle Modes
-
-| Mode | What it generates | Performance |
+| Setting | Default | What it does |
 |---|---|---|
-| **Full** (default) | Complete transcription of all speech | Fast -- single whisper run per audio track |
-| **Forced Only** | Only foreign-language dialogue (e.g., French lines in an English movie) | Slow -- see below |
-| **Full + Forced** | Both files per track | Slowest -- runs both pipelines |
-| **Translation Only** | Only an English translated subtitle (skips native-language transcription) | Fast -- single `--translate` pass; medium/large models recommended |
+| `JobTimeoutRealtimeFactor` | `6` | How much slower than real-time a remote call may run before it is presumed hung. Per-call deadline = audio length x this factor. |
+| `JobMinTimeoutSeconds` | `60` | Floor for that deadline. |
+| `JobMaxTimeoutHours` | `12` | Ceiling for that deadline. |
+| `JobMaxRetries` | `3` | Auto-retries for a killed or failed job. `0` disables retrying. |
+| `TaskMaxRuntimeHours` | `6` | Cap on one scheduled sweep. It stops cleanly between items and resumes next run. `0` is unlimited. |
+| `LanguageDetectionSampleSeconds` | `30` | Audio sampled per chunk during forced-subtitle language detection. |
 
-> **Performance warning for Forced / Full + Forced modes:**
-> Forced subtitle generation uses a multi-step pipeline: audio extraction, VAD-based speech segmentation, then **per-chunk language detection** on every ~30-second segment of the movie. For a 2-hour film this means ~240 individual whisper calls just for detection, before any transcription begins. On CPU, this phase alone can take **10--20+ minutes per movie**. GPU acceleration helps significantly.
->
-> If you don't need forced subtitles (most users don't), use **Full** mode for much faster processing.
+Four more fields (`WhisperBinaryVariant`, `VocalSeparationBinaryVariant`, `VocalSeparationModelQuant`, `VadModelPath`) record what the plugin downloaded or resolved. They are not meant to be edited by hand.
 
-### Language Handling
+## In-page Generate Subtitles button
 
-The plugin supports three language modes:
+The plugin injects a script tag into Jellyfin's `index.html` to add a **Generate Subtitles** entry to the item page. Direct on-disk injection is the default and needs a writable web root, which containers often do not have. If yours is read-only, install the [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugin from `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` and WhisperSubs registers a serve-time injection instead, with no permission changes. Both mechanisms coexist safely. The status panel at the top of the settings page shows which one is active, and `Setup/InjectionStatus` reports the same in JSON.
 
-1. **Auto-detect (recommended)** -- The plugin uses FFprobe to read the audio stream's language tag (e.g., `spa` → `es`, `eng` → `en`). Subtitles are generated in the language that matches the audio. If a file has multiple audio tracks in different languages, subtitles are generated for each one.
+## REST API
 
-   **Multiple audio languages.** By default (`AudioLanguageSelection = All`) every audio track's language is transcribed, producing one `.<lang>.generated.srt` per language (e.g. a Spanish + English file yields both `Movie.es.generated.srt` and `Movie.en.generated.srt`, each transcribed from its own audio track). Set **Audio Languages (auto-detect)** to `Primary audio track only` (`AudioLanguageSelection = PrimaryOnly`) to transcribe only the first/primary audio track and skip the secondary ones. This only affects auto-detect on multi-language files; a specific default language, or a file with no audio language tags, already resolves to a single track. The English translation pass is independent of this setting.
-
-2. **Whisper auto-detection** -- When no language metadata is available, the request falls through to whisper's built-in language detection (`-l auto`), which analyzes the first 30 seconds of audio.
-
-3. **Forced language** -- Set a specific language code (e.g., `es`) in the configuration or per-request via the API. This overrides detection and tells whisper to transcribe using that language model.
-
-### Subtitle Timing
-
-whisper.cpp emits subtitle segments back-to-back with no gaps, so the next line can appear on screen during the pause *before* it is actually spoken. The plugin corrects this, and the relevant settings are **on by default**:
-
-| Setting | What it does |
-|---|---|
-| **Enable VAD** | Runs whisper-cli with its native **Silero Voice Activity Detection** (`--vad`), so each cue starts at the real speech onset rather than during the preceding silence. The Silero VAD model (~865 KB) is auto-downloaded into the plugin's `whisper/vad/` data directory on first use. This is the primary speech-onset mechanism. |
-| **Silero VAD model** | Selects the Silero VAD model version: **v5.1.2** (default -- preserves existing timing on upgrade) or **v6.2.0** (newer, opt-in). The chosen model (~885 KB) is downloaded automatically on the next run if not already present. |
-| **VAD threshold** | Speech probability cutoff (`--vad-threshold`). Lower values detect more speech; higher values are stricter. Default: `0.5`. Leave blank to use whisper's built-in default. The six VAD tuning settings below apply only when **Enable VAD** is on. |
-| **VAD min speech duration** | Minimum speech segment length in milliseconds to keep (`--vad-min-speech-duration-ms`). Default: `250`. |
-| **VAD min silence duration** | Minimum silence gap in milliseconds before a segment boundary (`--vad-min-silence-duration-ms`). Default: `100`. |
-| **VAD max speech duration** | Maximum speech segment length in seconds before a forced split (`--vad-max-speech-duration-s`). Default: unlimited. |
-| **VAD speech pad** | Padding in milliseconds added around each detected speech chunk (`--vad-speech-pad-ms`). Default: `30`. |
-| **VAD samples overlap** | Overlap fraction between consecutive analysis windows (`--vad-samples-overlap`). Default: `0.1`. |
-| **Align subtitles to speech** | Older, energy-based fallback. Snaps each subtitle's start to the detected speech onset using a quick FFmpeg silence-detection pass over the audio. Used only when **Enable VAD** is off (native VAD handles this more reliably). |
-| **Also align VAD / worker timestamps to speech** | If lines still appear early with local VAD or worker/provider timestamps, also runs the forward-snap above. Off by default; requires **Align subtitles to speech** on. Only moves a start later, never earlier (though on coarse audio it may push a few starts slightly late). |
-| **Compensate audio start offset** | Shifts all subtitle timestamps by the audio stream's container start time, keeping subtitles in sync when a file's audio doesn't begin exactly at 0:00. |
-
-> These corrections run against the audio extracted on the Jellyfin server, so they apply to both local whisper-cli output and timestamped remote/worker output for full and translated subtitles. Remote/provider-owned timing requires the explicit **Also align VAD / worker timestamps to speech** opt-in. Forced subtitles are unaffected.
->
-> With native VAD enabled (the default), the FFmpeg silence-detection pass is skipped -- unless **Also align VAD / worker timestamps to speech** is enabled, which layers it on top for content where lines still appear early.
-
-## Vocal Separation (Optional)
-
-[BSRoformer.cpp](https://github.com/chenmozhijin/BSRoformer.cpp) is an optional enhancement that isolates vocals from background music and noise **before** transcription. This improves accuracy when content has heavy background noise or music.
-
-**Vocal separation is fully optional and fail-soft:** if the binary or model is missing or encounters an error, the plugin falls back to transcribing the original unseparated audio. A failed or hung custom separator can add processing time before its timeout, but it does not prevent transcription.
-
-### Setup
-
-On supported platforms (Linux x64/arm64, macOS x64/Apple Silicon, and Windows x64), the plugin can download `bs_roformer-cli` automatically from the settings page:
-
-1. Go to **Dashboard** > **Plugins** > **WhisperSubs**.
-2. Scroll to the **Vocal Separation** section.
-3. In the binary panel, choose a variant and click **Download**.
-4. In the model panel, choose a quantization and click **Download**.
-5. Turn on **Separate vocals from background noise/music before transcription**.
-
-Linux/macOS archive extraction requires `tar` with xz support. Linux builds also require `libgomp1`; the Vulkan build additionally requires `libvulkan1` and a compatible Vulkan driver. Windows requires the Microsoft Visual C++ 2015–2022 Redistributable. GPU variants are experimental: setup verifies that the CLI launches, but cannot prove real GPU inference compatibility. A setup-time validation failure falls back to CPU; an inference-time failure safely falls back to the original audio for that transcription.
-
-For a custom build or path, use the advanced fields described below.
-
-### Configuration
-
-| Setting | Description |
-|---|---|
-| **Separate vocals from background noise/music before transcription** | Master switch. Gracefully falls back to the original audio if separation is unavailable or fails. |
-| **BSRoformer binary path** | *(Advanced)* Absolute path to a custom `bs_roformer-cli`. The downloader fills this automatically. |
-| **BSRoformer model path** | *(Advanced)* Absolute path to a compatible GGUF model. The downloader fills this automatically. |
-| **Chunk overlap** | How many times each chunk is blended with its neighbours. Leave empty (or use `0`) for the selected model's own default. |
-| **Chunk size** | Audio window in samples at 44.1 kHz. Leave empty for the selected model's own default. Larger values require more memory. |
-
-### Installing BSRoformer.cpp
-
-The plugin requires the `bs_roformer-cli` binary and a GGUF model for vocal separation.
-
-#### Pre-built Binary (Recommended)
-
-The settings-page downloader is preferred because it verifies the pinned archive and model hashes, repairs the upstream archive's native-library aliases, validates the CLI, and replaces an existing installation transactionally.
-
-For a custom pre-built installation:
-
-1. Download the pinned release for your platform from [BSRoformer.cpp releases](https://github.com/chenmozhijin/BSRoformer.cpp/releases/tag/v0.1.0).
-2. Extract the **whole archive** to a persistent directory; keep `bs_roformer-cli` beside all bundled GGML libraries. Create the missing major-version aliases expected by the native loader (for example, `libggml-base.so.0` pointing to `libggml-base.so.0.15.1` on Linux).
-3. Download a GGUF model:
-   ```bash
-   mkdir -p /opt/roformer/models
-   # Q8_0 (recommended) ~56 MB, high quality
-   wget -O /opt/roformer/models/BSRoformer-anvuew-Q8_0.gguf \
-     https://huggingface.co/chenmozhijin/BSRoformer-GGUF/resolve/df802a6773d25ba6ef785ff619daa3e510503168/anvuew/BS-RoFormer/BSRoformer-anvuew-Q8_0.gguf
-   echo 'f0b0093b29ec92aaf6a866973996953a6687df02e0cad68a3833672060c177af  /opt/roformer/models/BSRoformer-anvuew-Q8_0.gguf' | sha256sum -c -
-   ```
-4. Expand **Separation tuning (advanced)** and set **BSRoformer binary path** and **BSRoformer model path** to the container-visible files, then save.
-
-> **Unraid:** keep custom assets under a persistent host path such as `/mnt/user/appdata/roformer` and bind-mount it into the container. Do not rely on the host root filesystem or a container-only `/opt` directory; those can be lost on host reboot or container recreation/update.
-
-#### Build from Source (CPU only)
-
-```bash
-git clone --branch v0.1.0 https://github.com/chenmozhijin/BSRoformer.cpp.git
-git clone https://github.com/ggerganov/ggml.git
-cmake -S BSRoformer.cpp -B BSRoformer.cpp/build \
-  -DGGML_DIR="$PWD/ggml" -DGGML_CUDA=OFF -DBUILD_SHARED_LIBS=OFF
-cmake --build BSRoformer.cpp/build --config Release -j$(nproc)
-# Binary: BSRoformer.cpp/build/bs_roformer-cli
-```
-
-#### Build with GPU Acceleration
-
-See [BSRoformer.cpp documentation](https://github.com/chenmozhijin/BSRoformer.cpp) for CUDA, ROCm, and Vulkan builds.
-
-### Container Setup
-
-If Jellyfin runs in Docker, install the runtime/extraction dependencies before using the automatic downloader:
-
-```yaml
-# docker-compose.yml
-services:
-  jellyfin:
-    image: jellyfin/jellyfin
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        dpkg -s libgomp1 xz-utils >/dev/null 2>&1 || \
-          (apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 xz-utils && \
-           rm -rf /var/lib/apt/lists/*)
-        exec /jellyfin/jellyfin
-```
-
-For a custom installation, also bind-mount its directory and use the container-internal paths in the advanced fields. Add `libvulkan1` and your GPU device/driver configuration when selecting Vulkan.
-
-The BSRoformer.cpp code is MIT-licensed. The selected anvuew BS-RoFormer model is distributed under GPL-3.0; the plugin downloads it from the upstream GGUF repository and does not bundle it.
-
-## Usage
-
-### Admin Dashboard
-
-The plugin adds a dedicated page to the Jellyfin admin dashboard (accessible from **Dashboard** > **Plugins** > **WhisperSubs**, or from the main sidebar menu). From there you can:
-
-- **Configure** the plugin settings (language, subtitle mode, binary/model paths, enabled libraries).
-- **Manage the whisper engine** -- download binaries (CPU / Vulkan / CUDA / ROCm) and models directly from the UI.
-- **Browse** all libraries and their items.
-- **See** which items already have subtitles (green check / orange cross).
-- **Select a language** for subtitle generation (auto-detect or any specific language).
-- **Generate** subtitles for individual items with a single click.
-- **Monitor progress** -- a live banner shows the current item, processing phase, and queue depth.
-
-### REST API
-
-All endpoints require Jellyfin admin authentication. Setup endpoints additionally require elevated privileges.
-
-**Library & Items**
-
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/Plugins/WhisperSubs/Libraries` | List all media libraries |
-| `GET` | `/Plugins/WhisperSubs/Libraries/{libraryId}/Items` | List items in a library (supports `startIndex` and `limit`) |
-| `POST` | `/Plugins/WhisperSubs/Items/{itemId}/Generate?language=auto` | Queue subtitle generation (priority) |
-| `GET` | `/Plugins/WhisperSubs/Items/{itemId}/AudioLanguages` | Detect audio languages in a media file |
-| `GET` | `/Plugins/WhisperSubs/Items/{itemId}/Status` | Check subtitle generation status |
-
-**Queue & Task**
-
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/Plugins/WhisperSubs/Queue` | Queue status: current item, progress, phase, remaining count. Also returns `pending` (inbound items in the order they will run) and `workers` (live per-worker load -- which endpoint is transcribing what) for the worker pool. |
-| `POST` | `/Plugins/WhisperSubs/Workers/TestConnection` | Test a worker endpoint: POSTs a tiny silent clip to confirm reachability, auth, and a working transcribe path before you save it. Returns `{ok, latencyMs, message}`. |
-| `POST` | `/Plugins/WhisperSubs/RunTask` | Trigger the scheduled subtitle generation task |
-| `GET` | `/Plugins/WhisperSubs/Models` | List downloaded models with active/size info |
-
-**Engine Setup** (requires elevated privileges)
-
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/Plugins/WhisperSubs/Setup/Status` | Binary/model status, GPU detection, platform info |
-| `GET` | `/Plugins/WhisperSubs/Setup/BinaryVariants` | Available binary variants for this platform |
-| `POST` | `/Plugins/WhisperSubs/Setup/DownloadBinary?variant=cpu` | Download whisper-cli binary |
-| `GET` | `/Plugins/WhisperSubs/Setup/AvailableModels` | Model catalog with sizes and descriptions |
-| `POST` | `/Plugins/WhisperSubs/Setup/DownloadModel?name=...` | Download a model from HuggingFace |
-| `GET` | `/Plugins/WhisperSubs/Setup/Progress` | Download progress (percent, message, errors) |
-| `POST` | `/Plugins/WhisperSubs/Setup/Models/{filename}/Activate` | Set a downloaded model as active |
-| `DELETE` | `/Plugins/WhisperSubs/Setup/Models/{filename}` | Delete a downloaded model |
-
-The `language` parameter accepts `auto` (default), or any ISO 639-1 code (`en`, `es`, `fr`, etc.).
-
-### Scheduled Task
-
-A scheduled task named **Generate Subtitles** is registered under the **WhisperSubs** category. It can be configured in **Dashboard** > **Scheduled Tasks** with your preferred schedule or triggered manually. The task:
-
-1. Scans all enabled libraries (or all libraries if none are explicitly selected).
-2. Finds video items that lack subtitles.
-3. Generates subtitles using the configured default language (auto-detect by default).
-4. Reports progress in the Jellyfin task UI.
-
-#### Skipping Already-Subtitled Media
-
-The auto-generation task skips media that already has a usable subtitle in the needed language, so an already-subtitled library is not needlessly re-processed. For the translation pass, an existing English subtitle track -- embedded **or** external -- counts as already translated and is skipped. Forced (foreign-dialogue-only) and image-based subtitle tracks do **not** count as satisfying the need, so full subtitles are still generated when only those are present.
-
-These settings control it. The skip toggles and **Generate original-language subtitles** are **on by default**; **translation** and the image-subtitle toggle are **off by default**:
-
-| Setting | What it does |
-|---|---|
-| **Skip media that already has subtitles** | Skips media that already has a usable subtitle in the needed language, including an existing English subtitle when translating. |
-| **Ignore forced subtitles when skipping** | Forced subtitle tracks do not count as "already subtitled", so full subtitles are still generated when only forced tracks exist. |
-| **Generate original-language subtitles** | The main switch: transcribe each title in its own spoken language — a Korean film gets Korean, an English film gets English. On by default. |
-| **Count image-based subtitles as present** | When on, existing image-based subtitles (PGS/VOBSUB) count as "already subtitled" and no text subtitle is generated. Off by default, since image subs can't be searched or edited. |
-| **Also create an English subtitle when a title has none** | Translation to English. For a title whose audio isn't English and that has no English subtitle, additionally produce one. Skips titles that already have English audio or an English subtitle. Off by default. |
-
-> **What Whisper can produce:** Whisper transcribes the speech it hears, so it writes a subtitle in the title's **own audio language** — that's the **Generate original-language subtitles** switch (an English film naturally gets English subtitles here). The one thing it can additionally do is **translate to English**: that's the separate **Translation** toggle, which only ever *adds* an English subtitle to a foreign-language title that doesn't already have one. There are no other targets — English is the only language Whisper translates *into*.
->
-> **Scope:** the skip logic and these toggles apply to the **scheduled auto-generation task** and bulk "Generate all" actions. A **manual "Generate" on a single item always transcribes** (it bypasses the skip and the original-language toggle), so you can force fresh subtitles for a file even when it already has some — e.g. to replace a poor embedded track.
->
-> **Note:** detection reads each item's subtitle streams from Jellyfin's library metadata, so a recent library scan keeps it accurate. If an item hasn't been scanned yet, the plugin errs toward generating rather than wrongly skipping.
-
-## How It Works
-
-1. **Language Detection** -- FFprobe reads the audio stream metadata to determine the spoken language(s).
-2. **Audio Extraction** -- FFmpeg extracts a 16 kHz mono WAV track from the media file.
-3. **Transcription** -- The extracted audio is passed to whisper.cpp, which produces an SRT subtitle file. For forced subtitles, the audio is first segmented via VAD (silence detection), then each ~30-second chunk is language-classified before selectively transcribing only foreign-language segments.
-4. **Output** -- Files are saved alongside the original media:
-   - Full subtitles: `Movie.es.generated.srt`
-   - Forced subtitles: `Movie.es.forced.generated.srt`
-   - Lyrics: `Song.lrc`
-5. **Metadata Refresh** -- The item's metadata is refreshed so Jellyfin picks up the new files immediately.
-
-Temporary audio files are cleaned up automatically after processing. Items that have already been processed are tracked with marker files (`.noforeignlang`) to avoid redundant work on subsequent scans.
+36 endpoints live under `/Plugins/WhisperSubs/`. All of them require authentication. Everything except the four user-request endpoints (`Requests/Capabilities`, `Items/{id}/Request`, `Requests/Mine`, `Items/{id}/RequestStatus`) requires a Jellyfin admin. [Diagnostics](https://geiserx.github.io/whisper-subs/diagnostics/) shows how to call `Setup/Status`, `Queue` and `Setup/InjectionStatus`, which are the three worth capturing when something goes wrong.
 
 ## Roadmap
 
@@ -671,11 +157,10 @@ See [ROADMAP.md](ROADMAP.md) for planned features and design details.
 
 ## Other Jellyfin Projects by GeiserX
 
-- [smart-covers](https://github.com/GeiserX/smart-covers) — Cover extraction for books, audiobooks, comics, magazines, and music libraries with online fallback
-- [quality-gate](https://github.com/GeiserX/quality-gate) — Restrict users to specific media versions based on configurable path-based policies
-- [jellyfin-encoder](https://github.com/GeiserX/jellyfin-encoder) — Automatic 720p HEVC/AV1 transcoding service with hardware acceleration
-- [jellyfin-telegram-channel-sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) — Sync Jellyfin access with Telegram channel membership
-
+- [smart-covers](https://github.com/GeiserX/smart-covers): cover extraction for books, audiobooks, comics, magazines and music libraries, with online fallback
+- [quality-gate](https://github.com/GeiserX/quality-gate): restrict users to specific media versions based on configurable path-based policies
+- [jellyfin-encoder](https://github.com/GeiserX/jellyfin-encoder): automatic 720p HEVC/AV1 transcoding service with hardware acceleration
+- [jellyfin-telegram-channel-sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync): sync Jellyfin access with Telegram channel membership
 
 ## Supporters
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The label is both the title shown in Jellyfin's subtitle picker and the marker t
 | **Full + forced** | Both, per audio track |
 | **Translation only** | An English translated subtitle, skipping native-language transcription |
 
-The scheduled task skips media that already has a usable subtitle in the needed language. Forced and image-based tracks do not satisfy that need unless you turn on **Count image-based subtitles as present**. A manual **Generate** on a single item always transcribes, bypassing the skip.
+The scheduled task skips media that already has a usable subtitle in the needed language. Forced tracks do not satisfy that need while **Ignore forced subtitles when skipping** is on (the default), and image-based tracks do not unless you turn on **Count image-based subtitles as present**. They are two independent settings. A manual **Generate** on a single item always transcribes, bypassing the skip.
 
 ## User subtitle requests
 

--- a/site/docs/api-and-internals.md
+++ b/site/docs/api-and-internals.md
@@ -1,0 +1,178 @@
+---
+title: API and internals
+description: The REST endpoints, how a subtitle gets made, and the files the plugin writes.
+sidebar_position: 7
+---
+
+# API and internals
+
+Everything the settings page does, it does over HTTP. This page lists those endpoints, walks the transcription pipeline from trigger to file on disk, and names every file the plugin owns.
+
+## The REST API {#rest-api}
+
+All 36 endpoints live under `/Plugins/WhisperSubs`. Two controllers share that prefix: 32 admin endpoints and 4 user-facing ones.
+
+Every admin endpoint needs an administrator token. [Diagnostics](/diagnostics) covers creating an API key and which header to send. A browser tab sends no credentials, so opening any of these URLs directly returns 401.
+
+### Admin endpoints {#admin-endpoints}
+
+The whole controller carries `[Authorize(Policy = "RequiresElevation")]`, so **admin only**, with no exceptions. The `Setup/*` methods repeat the attribute individually; that is redundant, not different.
+
+**Libraries and items**
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Libraries` | Every Jellyfin library, as id and name. |
+| GET | `Libraries/{libraryId}/Items` | A page of media items: id, name, type, path, and whether Jellyfin already sees subtitles. Query: `startIndex` (0), `limit` (50), `searchTerm`. |
+| GET | `Items/{itemId}/AudioLanguages` | The ISO 639-1 codes tagged on the file's audio streams, read with FFprobe. |
+| GET | `Items/{itemId}/Status` | Whether a plugin-generated full or forced subtitle exists for the item, plus the path. Query: `language`, defaulting to the configured one. `auto` checks any language. |
+| POST | `Items/{itemId}/Generate` | 202. Queues one item at the admin tier, forced, so it regenerates even when a usable subtitle already exists. Query: `language`. |
+| POST | `Items/{itemId}/GenerateAll` | 202. Expands a series, season or album to its media items and queues each one. Unlike `Generate` this does not force, so it fills gaps rather than redoing work. Query: `language`. |
+
+`GenerateAll` only accepts a movie, episode, audio track, series, season or album. A library root, a collection or a plain folder is rejected with 400, so a single call cannot sweep the whole library.
+
+**Queue and workers**
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Queue` | The live queue: what is processing, what is left, counts of processed and failed, the last error, the current phase, a per-tier breakdown, how many user requests await approval, the next items in run order, and which worker holds which job. |
+| POST | `Workers/TestConnection` | `{ok, message}`. Posts a short silent WAV to the worker's transcription route to prove reachability, auth and a working transcribe path. Never touches your library. Takes a worker definition as the JSON body. |
+| POST | `Workers/Reload` | Reconciles the running worker pool with the saved configuration and returns the resulting worker count. A just-added worker joins the current drain without a Jellyfin restart. |
+| POST | `RunTask` | Queues the Generate Subtitles scheduled task immediately. |
+
+**User requests**
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Requests` | Every user request, newest first: item name, type, language, requester, tier, state, timestamps. Never a filesystem path. |
+| POST | `Requests/{requestId}/Approve` | Moves the request from Pending to Queued and enqueues its items. 409 if it is not Pending, 404 if it does not exist. |
+| POST | `Requests/{requestId}/Decline` | Moves the request from Pending to Declined. Same 409 and 404 behaviour. |
+
+**Setup: the whisper engine**
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Setup/Status` | Whether the binary and model are configured and present, with their paths, the detected platform and GPU. |
+| GET | `Setup/Progress` | Progress of the running download, if any. |
+| GET | `Setup/AvailableModels` | The whisper model catalogue offered for download. |
+| GET | `Setup/BinaryVariants` | The `whisper-cli` variants published for this platform. |
+| GET | `Models` | The `.bin` models already on disk, with size and which one is active. |
+| POST | `Setup/DownloadModel` | 202, download runs in the background. 409 if one is already running. Query: `name`, a catalogue filename. |
+| POST | `Setup/DownloadBinary` | 202. Query: `variant`, defaulting to `cpu`. 400 for a variant not published for the platform. |
+| POST | `Setup/DownloadVadModel` | 202. Fetches the Silero VAD model, roughly 865 KB. |
+| POST | `Setup/Models/{filename}/Activate` | Points the configuration at that model file and saves. |
+| DELETE | `Setup/Models/{filename}` | Deletes a downloaded model. Refuses the active model and the last remaining one. |
+| POST | `Setup/ClearSkipCache` | Deletes the skip cache so the next scheduled run re-checks every item. Returns `{cleared}`. |
+| GET | `Setup/InjectionStatus` | Whether the in-page client script is present in `index.html`, including a check of the HTML Jellyfin actually serves. |
+| POST | `Setup/ReinjectScript` | Re-runs the script injection and returns the fresh status. Fixes a missing Generate Subtitles button without a restart. |
+
+**Setup: vocal separation**
+
+These mirror the whisper endpoints for the BSRoformer.cpp binary and model. They use a separate download lock, so a download here never collides with a whisper download.
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Setup/VocalSeparation/Status` | Whether `bs_roformer-cli` and a GGUF model are configured and present. |
+| GET | `Setup/VocalSeparation/Progress` | Progress of the running vocal-separation download. |
+| GET | `Setup/VocalSeparation/AvailableModels` | The GGUF quantizations offered for download. |
+| GET | `Setup/VocalSeparation/BinaryVariants` | The BSRoformer.cpp variants published for this platform. |
+| POST | `Setup/VocalSeparation/DownloadBinary` | 202. Query: `variant`, defaulting to `cpu`. |
+| POST | `Setup/VocalSeparation/DownloadModel` | 202. Query: `quant`, a catalogue key such as `q8_0`. |
+
+### User endpoints {#user-endpoints}
+
+Four endpoints let a signed-in user ask for subtitles instead of waiting for an admin. They live in their own controller with a plain `[Authorize]`, so **any authenticated user** can reach them. That is deliberate: opening one method on the admin controller would have meant dropping its class-level elevation, and an un-attributed method in Jellyfin becomes public.
+
+Three further gates apply on every call:
+
+- The feature must be on. With **Allow user requests** off, all four behave as if they do not exist and return 404.
+- An API key is not enough. These endpoints re-derive the user from the session and reject key-only calls with 401, because a key carries no per-user visibility.
+- The item must be visible to that user. An item they cannot see returns 404, never 403.
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `Requests/Capabilities` | Whether requests are enabled, whether they auto-approve, the user tier, and the daily and active limits. Drives the client script showing or hiding the request entry. |
+| POST | `Items/{itemId}/Request` | 202 when the request is created, 200 when it duplicates an active one. 429 over the daily quota or the per-user active cap, 503 when the global queue cap is full, 400 for an unsupported item type or language. Query: `language`. |
+| GET | `Requests/Mine` | That user's own requests only. Never anyone else's, never a file path. |
+| GET | `Items/{itemId}/RequestStatus` | That user's active request state for one item, which is what the item-page badge reads. |
+
+The tier of a user request is assigned on the server from the requester's role. It is never read from the request body.
+
+## How a subtitle gets made {#pipeline}
+
+Three things start a job: the nightly scheduled task, a manual **Generate** from the item page or the API, and an approved user request. All three put the item on the same queue, and a background drain hands jobs to whichever worker is free. The queue survives a restart.
+
+Once a job starts, this is what happens.
+
+**1. Work out the language.** With a specific language configured, that is the language. With `auto`, FFprobe reads the language tags off the audio streams and every distinct code found gets its own pass. When the file carries no tags at all, the plugin extracts the first 30 seconds and lets whisper detect the language.
+
+**2. Decide which passes apply.** A run can produce up to three kinds of subtitle: the full transcription in the audio's own language, a forced subtitle holding only the foreign-language dialogue, and an English translation. Which ones run comes from the subtitle mode and the translation and original-language toggles. A pass that would overwrite a usable existing subtitle is skipped, unless the job was forced by a manual Generate.
+
+**3. Resume or start fresh.** If the plugin's own partial subtitle for that language is already on disk, the run resumes from two seconds before its last cue and appends, renumbering as it goes. If that last cue is within 30 seconds of the end of the media, the file counts as finished and the pass is skipped.
+
+**4. Extract the audio.** FFmpeg writes 16 kHz mono PCM to the system temp directory, mapping the audio stream that matches the target language. Jellyfin's own bundled FFmpeg at `/usr/lib/jellyfin-ffmpeg/ffmpeg` is preferred over one on the PATH.
+
+**5. Separate the vocals, if enabled.** With vocal separation on and configured, the extraction runs at 44.1 kHz instead, `bs_roformer-cli` isolates the vocal track, and the result is downsampled to the 16 kHz whisper expects. Only one separation runs at a time across the whole server. If the binary or model is missing, or the process fails, the job continues on the original mix rather than failing. See [Vocal separation](/docs/setup#vocal-separation).
+
+**6. Transcribe.** The assigned worker transcribes the WAV: local `whisper-cli`, a remote worker or a hosted API. The forced pass works differently. It splits the audio on silence, runs language detection on each speech chunk, and transcribes only the chunks whose language is not the primary one.
+
+**7. Correct the timings.** Optional speech alignment nudges each cue start onto a detected speech onset. Optional offset compensation then shifts the whole file by the audio stream's container start time, which matters on broadcast and transport-stream recordings. Alignment runs first, while both the cues and the detected speech are still on the extracted WAV's zero-based clock, so the offset is applied exactly once.
+
+**8. Save the file.** The SRT is written with a temporary file and a rename, so a crash mid-write cannot leave a truncated subtitle. It lands next to the media when the library has **Save subtitles into media folders** on and that folder is writable. Otherwise it goes to the item's Jellyfin metadata folder, which Jellyfin scans for external subtitles just the same. That fallback is what makes read-only libraries work.
+
+**9. Refresh the item.** The plugin calls `RefreshMetadata` on the item so the new track appears without a library scan.
+
+If every pass in a job failed, the job is reported as failed rather than quietly succeeding.
+
+## Files the plugin writes {#files}
+
+### Subtitles, next to your media
+
+Filenames come from a template, `{name}.{lang}.{label}{.type}` by default, with `WhisperSubs` as the label. The label doubles as the ownership marker and as the title Jellyfin shows in the subtitle picker. Change either in Advanced settings and new files follow the new pattern.
+
+| File | Written by |
+|---|---|
+| `Movie.es.WhisperSubs.srt` | The full transcription pass. |
+| `Movie.es.WhisperSubs.forced.srt` | The forced pass, holding only foreign-language dialogue. |
+| `Movie.en.WhisperSubs.translated.srt` | The English translation pass. |
+| `Track.lrc` | Lyrics for an audio track, named to match the file, which is what Jellyfin's lyric resolver expects. |
+| `Movie.es.forced.noforeignlang` | An empty marker file. |
+
+Subtitles written before v4 used `.generated.` and `.translated.` in place of the label. Those are still recognised as the plugin's own, so an upgraded install resumes and skips them correctly rather than writing a second copy.
+
+The `.noforeignlang` marker is worth understanding. When the forced pass analyses a file and finds no foreign dialogue anywhere in it, that is an expensive answer to compute and an empty subtitle would show up as a broken track in the player. So the plugin writes this empty marker instead, and every later run sees it and skips the analysis. Delete it to force a re-analysis. Note that its name is built directly from the media filename, so it stays `Movie.es.forced.noforeignlang` whatever you set the label and template to.
+
+All of these follow the same save-location rule as the subtitles: media folder when it is writable and the library allows it, the item's metadata folder otherwise.
+
+### State, in the plugin data folder
+
+Three JSON files live in the plugin's data folder, which is `/config/data/WhisperSubs` on a standard Docker install. All three are written with a temporary file and a rename.
+
+| File | Holds |
+|---|---|
+| `queue.json` | The pending queue, with each item's language, priority tier, forced flag and retry count. Restored on startup, so a restart does not lose queued work. |
+| `requests.json` | User subtitle requests and their states, which is what the approval panel reads. |
+| `skip-cache.json` | Per-item record of what was already checked, so a repeat scan does not re-probe the filesystem for every item. Clear it from the settings page or `POST Setup/ClearSkipCache`. |
+
+### The engine, in the plugin data folder
+
+| Path | Holds |
+|---|---|
+| `whisper/whisper-cli` | The transcription binary. `whisper-cli.exe` on Windows. |
+| `whisper/models/` | Downloaded whisper models, as `.bin` files. The active one is set in the configuration. |
+| `whisper/vad/` | The Silero VAD model, `ggml-silero-v5.1.2.bin`. Kept in its own directory so it is never mistaken for a transcription model. |
+| `whisper/detect/` | The dedicated language-detection model, `ggml-base.bin`. Separate for the same reason. |
+| `vocal-separation/bin/` | The extracted `bs_roformer-cli` and any libraries shipped alongside it. Wiped and re-extracted on every download, so a stale library from a previous variant cannot linger. |
+| `vocal-separation/models/` | The downloaded GGUF vocal-separation model. |
+
+Working files go to the system temp directory and are deleted when the job ends, including on failure and cancellation. Nothing permanent is kept there.
+
+## The scheduled task {#scheduled-task}
+
+The task is called **Generate Subtitles** and appears under **Dashboard → Scheduled Tasks** in the WhisperSubs category. It scans the enabled libraries and queues anything missing subtitles.
+
+It ships with two triggers: daily at 02:00, and once on server startup. Both are defaults. Change them, add triggers or remove them entirely from the same Scheduled Tasks page, exactly as you would for any built-in Jellyfin task.
+
+Two things stop it early: **Enable automatic generation** turned off, and neither a model path nor a remote worker URL configured. Both are written to the log.
+
+`POST RunTask` queues the same task on demand, which is what the settings page button does.

--- a/site/docs/api-and-internals.md
+++ b/site/docs/api-and-internals.md
@@ -16,7 +16,7 @@ Every admin endpoint needs an administrator token. [Diagnostics](/diagnostics) c
 
 ### Admin endpoints {#admin-endpoints}
 
-The whole controller carries `[Authorize(Policy = "RequiresElevation")]`, so **admin only**, with no exceptions. The `Setup/*` methods repeat the attribute individually; that is redundant, not different.
+The whole controller carries `[Authorize(Policy = "RequiresElevation")]`, so **admin only**, with no exceptions. Most of the `Setup/*` methods repeat the attribute individually; that is redundant, not different.
 
 **Libraries and items**
 
@@ -83,11 +83,16 @@ These mirror the whisper endpoints for the BSRoformer.cpp binary and model. They
 
 Four endpoints let a signed-in user ask for subtitles instead of waiting for an admin. They live in their own controller with a plain `[Authorize]`, so **any authenticated user** can reach them. That is deliberate: opening one method on the admin controller would have meant dropping its class-level elevation, and an un-attributed method in Jellyfin becomes public.
 
-Three further gates apply on every call:
+The gates are not the same on all four.
 
-- The feature must be on. With **Allow user requests** off, all four behave as if they do not exist and return 404.
-- An API key is not enough. These endpoints re-derive the user from the session and reject key-only calls with 401, because a key carries no per-user visibility.
-- The item must be visible to that user. An item they cannot see returns 404, never 403.
+`Requests/Capabilities` answers for any authenticated user whether the feature is on, because the client script needs that answer either way to decide whether to show the request entry at all. It returns 200 with `enabled: false` when requests are switched off.
+
+The other three apply two gates:
+
+- The feature must be on. With **Allow users to request subtitles** off, they behave as if they do not exist and return 404.
+- An API key is not enough. They re-derive the user from the session and reject key-only calls with 401, because a key carries no per-user visibility.
+
+One further gate applies only to `Items/{itemId}/Request`: the item must be visible to that user. An item they cannot see returns 404, never 403, so the endpoint cannot be used to probe what exists.
 
 | Method | Path | Returns |
 |---|---|---|
@@ -162,7 +167,7 @@ Three JSON files live in the plugin's data folder, which is `/config/data/Whispe
 | `whisper/models/` | Downloaded whisper models, as `.bin` files. The active one is set in the configuration. |
 | `whisper/vad/` | The Silero VAD model, `ggml-silero-v5.1.2.bin`. Kept in its own directory so it is never mistaken for a transcription model. |
 | `whisper/detect/` | The dedicated language-detection model, `ggml-base.bin`. Separate for the same reason. |
-| `vocal-separation/bin/` | The extracted `bs_roformer-cli` and any libraries shipped alongside it. Wiped and re-extracted on every download, so a stale library from a previous variant cannot linger. |
+| `vocal-separation/bin/` | The extracted `bs_roformer-cli` and any libraries shipped alongside it. Replaced wholesale on every download on every download, so a stale library from a previous variant cannot linger. |
 | `vocal-separation/models/` | The downloaded GGUF vocal-separation model. |
 
 Working files go to the system temp directory and are deleted when the job ends, including on failure and cancellation. Nothing permanent is kept there.

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -1,0 +1,250 @@
+---
+title: Settings reference
+description: Every WhisperSubs setting, what it does, and its default.
+sidebar_position: 5
+---
+
+# Settings reference
+
+Everything below lives at **Dashboard → Plugins → WhisperSubs**, except the handful marked config file only. The sections follow the order of the settings page, so you can read down this page and down the screen at the same time.
+
+Defaults are the values a fresh install starts with.
+
+## Generation defaults
+
+| Setting | Default | What it does |
+|---|---|---|
+| Default Language | Auto-detect from audio (`auto`) | Reads the language tag from each audio stream and transcribes in that language. With no tags, whisper detects the spoken language and the file is written with language `auto`. Picking a specific language forces every transcription to use it. |
+| Audio languages (auto-detect) | All audio languages | Only applies when the language above is Auto-detect and the file carries more than one audio language. **All audio languages** transcribes every one of them, producing one subtitle per language. **Primary audio track only** transcribes just the first track. A specific language, or a file with no language tags, is one language already and is unaffected. |
+| Subtitle Mode | Full | Which passes run. See below. |
+
+### Subtitle modes
+
+| Mode | What it produces |
+|---|---|
+| **Full** | A complete transcription of all speech. |
+| **Forced Only** | Only the segments where the spoken language differs from the track's primary language, for example French dialogue inside an English film. |
+| **Full + Forced** | Both files, per track. |
+| **Translation Only (English)** | Skips native-language transcription entirely and produces only an English translation, in a single whisper pass. |
+
+Translation Only needs a model that can translate. The recommended turbo models cannot, so pick a medium or large non-turbo model for it. [Limitations](/limitations#the-recommended-model-cannot-translate) explains why.
+
+## Subtitle file naming
+
+| Setting | Default | What it does |
+|---|---|---|
+| Subtitle label | `WhisperSubs` | The brand written into the plugin's own subtitle filenames through the `{label}` token. With the default template it lands right after the language code, which makes it the Title shown in Jellyfin's subtitle picker. It is also the ownership marker the plugin matches to recognise its own sidecar files, so pick something distinctive. It is matched as a substring. |
+| Filename template | `{name}.{lang}.{label}{.type}` | The filename pattern, without the extension. |
+
+### Template tokens
+
+| Token | Expands to |
+|---|---|
+| `{name}` | The media filename without its extension. Treated as opaque, so dots inside a release name are never read as separators. |
+| `{lang}` | The language code, for example `en`. |
+| `{label}` | The subtitle label above. |
+| `{.type}` | `.translated`, `.forced`, or nothing for a full transcription. |
+| `{type}` | The same value without the leading dot. |
+
+A template must contain `{name}`, `{lang}` and `{label}`. The page shows a warning under the field when one is missing, and an invalid template that got saved anyway falls back to the default at the moment it is used, so it can never produce a broken filename.
+
+Empty segments are cleaned up after expansion: any `..` collapses to `.`, and a leading or trailing dot is trimmed. `Movie..srt` and `Movie.srt.` cannot happen.
+
+The three preset buttons fill the field with:
+
+```text
+Brand first (recommended)   {name}.{lang}.{label}{.type}
+Label at end                {name}.{lang}{.type}.{label}
+Keep .generated             {name}.{lang}.{label}.generated
+```
+
+:::warning[A template with no type token collides]
+The **Keep .generated** preset has no `{.type}`, so the type is simply dropped. Full, forced and translated output for the same language all expand to the same filename and overwrite each other. If you use a custom template, keep `{.type}` in it unless you run in Full mode only.
+:::
+
+Files written by older versions are still recognised. Anything containing `.generated.` or `.translated.` counts as the plugin's own output regardless of the current label, alongside the label-based `.WhisperSubs.` form.
+
+## Automation
+
+| Setting | Default | What it does |
+|---|---|---|
+| Enable Auto-Generation | Off | Lets the scheduled task sweep your libraries. With this off, subtitles are only ever produced by a manual Generate. |
+| Libraries | none selected | The checkbox list under Auto-Generation scopes the sweep. **With none selected, every library is scanned.** Selecting one or more restricts the sweep to those. It applies to the scheduled task only; a manual Generate on a single item ignores it. |
+| Enable Lyrics Generation (Experimental) | Off | Includes music libraries in the sweep and writes `.lrc` lyrics next to audio tracks. Whisper is trained on speech, not singing, so accuracy varies. See [Limitations](/limitations#lyrics-generation-is-experimental). |
+| Pause generation during playback | Off | Pauses transcription while any user is playing something, and resumes when playback stops. Useful when the same box transcodes and transcribes. |
+
+## Skipping media that already has subtitles
+
+| Setting | Default | What it does |
+|---|---|---|
+| Skip media that already has subtitles | On | The sweep skips media that already has a usable subtitle in the language it needs, embedded or external. For the translation pass, an existing English subtitle counts as already translated. |
+| Ignore forced subtitles when skipping | On | A forced subtitle track does not count as satisfying the need. Forced tracks only cover foreign-dialogue inserts, not the whole dialogue. |
+| Count image-based subtitles as present | Off | When on, image-based tracks (PGS, VOBSUB) count as an existing subtitle. Off by default because image subtitles cannot be searched or edited, so the plugin still writes a text one. |
+
+:::note[The two filters are independent]
+"Ignore forced subtitles" and "Count image-based subtitles as present" are separate tests, applied one after the other to the same stream. A stream has to pass both to count as an existing subtitle. Neither one governs the other: a forced image track is rejected by the forced test whatever the image setting says, and turning the image setting on does not make forced tracks count.
+:::
+
+The plugin's own output is always excluded from these checks, so a subtitle it generated last week never satisfies the check this week and stops it regenerating a file it just wrote.
+
+### Skip cache
+
+Re-checking the filesystem for every candidate item on every scheduled run is the slow part of a large library. The cache stores the per-item verdict so a repeat run can skip the probe.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Remember already-subtitled items between runs | On | Caches the "already has subtitles" verdict per item. An entry is reused only while the item's Jellyfin change token is unchanged and the skip settings above are unchanged. Any metadata or subtitle change, or any edit to a skip setting, re-checks the item. Scheduled task only. |
+| Skip-cache re-verify (days) | `30` | Backstop. Re-check a cached item after this many days even if nothing changed, so a subtitle you deleted outside Jellyfin is eventually regenerated. Deleting a file outside Jellyfin does not bump the change token until the next library scan, which is what this covers. `0` disables the time backstop and relies on the change token alone. |
+
+The **Clear skip cache now** button next to the field empties the cache immediately, so the next scheduled run re-checks every item from scratch.
+
+## Subtitle generation
+
+Whisper transcribes the speech it hears, so it can only write a subtitle in the title's own audio language. Turning that audio into English is a separate pass, covered under Translation below.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Generate original-language subtitles | On | The main generate switch. Transcribes each title in its own spoken language: a Korean film gets Korean subtitles, an English film gets English. Turning it off leaves the sweep producing only whatever forced or translated output the mode calls for. A manual single-item Generate always transcribes regardless of this setting. |
+
+## Translation to English
+
+English is the only language whisper can translate into.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Also create an English subtitle when a title has none | Off | For a title whose audio is not English and that has no English subtitle, additionally translate it. Titles with English audio, or an existing English subtitle, are skipped automatically, so this only fills a gap. Uses whisper's own `--translate`, no external service. |
+
+This applies only when Subtitle Mode includes Full subtitles. It does nothing in Forced Only, and it is implicit in Translation Only.
+
+## Subtitle timing
+
+### Why these settings exist
+
+whisper.cpp emits cues back to back. The start of one cue is the end of the previous one, with no gap, even across a silence where nobody is speaking. On screen that reads as a subtitle appearing during the pause before its line is actually spoken.
+
+There are two independent corrections for it:
+
+- **Native VAD** runs Silero voice activity detection inside whisper.cpp at transcription time, so a cue starts at real speech onset. This is the default and the better fix.
+- **The forward snap** is the older energy-based fallback. It runs an extra FFmpeg `silencedetect` pass over the audio already extracted on this server and moves each cue start forward to the nearest detected speech onset. It only ever moves a cue later, never earlier.
+
+Both apply to full and translated subtitles. Neither applies to forced subtitles or lyrics.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Use speech detection (VAD) | On | Passes `--vad` to whisper-cli with the Silero model. The model is about 865 KB and downloads automatically on first use. Local whisper-cli only: it does not apply to a remote worker, which owns its own timing, nor to forced subtitles. |
+| Align subtitles to speech (fallback) | On | Enables the FFmpeg forward snap. On its own it runs only when VAD is off. Leave it on so the fallback exists. |
+| Also align VAD / worker timestamps to speech | Off | Layers the forward snap on top of VAD output and on top of remote worker output. Turn this on if lines still appear early. Requires "Align subtitles to speech" to be on. Off by default because the energy-based detector proved unreliable on some real material and can push a few starts slightly late. |
+| Compensate audio start offset | On | Shifts every timestamp by the audio stream's start time, for containers whose audio does not begin at exactly 0:00. Applies to local and to timestamped remote output, for full and translated subtitles, not forced. |
+
+### When the forward snap actually runs
+
+| Timestamps came from | Align subtitles to speech | Also align VAD / worker timestamps | Forward snap runs |
+|---|---|---|---|
+| Local whisper-cli, VAD off | On | either | Yes |
+| Local whisper-cli, VAD on | On | Off | No |
+| Local whisper-cli, VAD on | On | On | Yes |
+| Remote worker or hosted provider | On | Off | No |
+| Remote worker or hosted provider | On | On | Yes |
+| anything | Off | either | No |
+
+### VAD tuning (advanced)
+
+Each of these maps to one `--vad-*` flag on whisper-cli, and each applies only when **Use speech detection (VAD)** is on.
+
+:::note[An empty field means "use whisper's own default"]
+Leave a tuning field empty and the plugin stores `-1`, which it treats as unset. No flag is emitted for it and whisper.cpp uses its built-in value. That is why the rows below quote a whisper default rather than a plugin one: on a fresh install the plugin sets none of them, and the command line it builds is identical to one with no tuning feature at all.
+
+**Max Speech Duration** additionally treats `0` as unset, because a zero second cap has no meaning.
+:::
+
+| Setting | Default | What it does |
+|---|---|---|
+| Silero VAD model | `v5.1.2` | Which Silero model whisper-cli loads. `v5.1.2` is the default and `v6.2.0` is a newer opt-in. Both are about 885 KB. An unset or unrecognised value falls back to `v5.1.2`, so upgrading never silently changes the model or shifts your timing. Selecting the other version downloads it on the next run. |
+| VAD Threshold | unset (whisper uses `0.5`) | Speech probability cutoff, `0` to `1`. Lower catches quieter speech and adds false positives. |
+| Min Speech Duration (ms) | unset (whisper uses `250`) | Segments shorter than this are dropped. |
+| Min Silence Duration (ms) | unset (whisper uses `100`) | How much silence has to sit between two speech segments before they are split. Raising it groups sentences together. |
+| Max Speech Duration (s) | unset (whisper leaves it unlimited) | Segments longer than this are split automatically. Around `30` limits timestamp drift on long unbroken takes. |
+| Speech Padding (ms) | unset (whisper uses `30`) | Padding added to each side of a speech segment so word edges are not clipped. |
+| Samples Overlap (s) | unset (whisper uses `0.1`) | Audio carried over between consecutive segments so a word on the boundary is not cut. |
+
+A matching flag placed in **Custom Whisper Arguments** supersedes the value set here. Custom arguments are appended last and whisper-cli takes the last value it sees.
+
+## Performance and advanced
+
+These sit under **Advanced / Manual Install** on the settings page.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Whisper Thread Count | `0` | CPU threads for whisper inference. `0` emits no `-t` flag, so whisper.cpp uses its own default of 4. Set it to your core count. On a 16-thread i5-14500 a 2h15m film drops from an estimated 7 hours to 1h48m. Language detection is separately capped at 4 threads whatever you set here, because per-chunk process spawning does not benefit from more. |
+| Maximum subtitle line length | `0` | Maximum characters per cue, emitted as `--max-len N` together with `--split-on-word` so a cap never breaks mid-word. `0` is unset, which leaves whisper.cpp's own default of unlimited. Raise it if subtitles arrive as one enormous run-on line: broadcast subtitling caps a line near 42 characters and `47` is a good starting point. Local whisper-cli only, since a remote worker owns its own segmentation. Set `WHISPER_MAX_LEN` on the worker instead. |
+| Custom Whisper Arguments | empty | Extra space-separated arguments appended to every whisper-cli invocation, for example `--beam-size 8`. Local whisper-cli only. |
+
+Arguments the plugin manages itself are blocked from that field: the model, input file, language, thread count, max context, non-speech suppression, every output format and the output path, `--translate`, `--detect-language`, `--prompt`, the offset and duration flags, and `--vad` with `--vad-model`. The VAD tuning flags and `--max-len` are deliberately **not** blocked, so you can override those settings from here.
+
+## Config file only
+
+These have no control on the settings page. They live in Jellyfin's plugin configuration file, at `<Jellyfin program data>/plugins/configurations/WhisperSubs.xml`:
+
+| Deployment | Path |
+|---|---|
+| `jellyfin/jellyfin` container, and the NAS app images built on it | `/config/plugins/configurations/WhisperSubs.xml` |
+| Debian or Ubuntu package on bare metal or in an LXC | `/var/lib/jellyfin/plugins/configurations/WhisperSubs.xml` |
+
+:::warning[Stop Jellyfin before editing it]
+Jellyfin holds the plugin configuration in memory and writes the whole file back whenever you press Save on the settings page. Editing the file while Jellyfin is running either has no effect or gets overwritten. Stop Jellyfin, edit, start it again.
+:::
+
+### Remote call deadlines
+
+Every call to a remote worker is bounded by a deadline derived from the length of the audio, rather than by a fixed HTTP timeout. The deadline is the audio length multiplied by the real-time factor, then clamped between the floor and the cap. A slow but working worker is never cut off; a dead endpoint fails instead of piling up.
+
+| Setting | Default | What it does |
+|---|---|---|
+| `JobTimeoutRealtimeFactor` | `6.0` | How much slower than real time a worker may run before a single call is presumed hung. |
+| `JobMinTimeoutSeconds` | `60` | Floor for the per-call deadline, so a tiny language-detection chunk still gets a sane minimum. |
+| `JobMaxTimeoutHours` | `12` | Absolute cap for the per-call deadline. |
+
+### Retries and sweep length
+
+| Setting | Default | What it does |
+|---|---|---|
+| `JobMaxRetries` | `3` | How many times a killed or failed job is automatically re-queued before the plugin gives up. It goes back at its original priority tier and the counter survives a Jellyfin restart. `0` disables auto-retry, dropping a killed job outright. |
+| `TaskMaxRuntimeHours` | `6` | Wall-clock cap on one sweep of the Generate Subtitles task. At the cap the sweep stops cleanly between items: finished work is kept, the skip cache is written, and the next scheduled run picks up where this one stopped. `0` means unlimited. |
+
+### Other config file values
+
+| Setting | Default | What it does |
+|---|---|---|
+| `LanguageDetectionSampleSeconds` | `30` | Seconds of audio, from the start of each chunk, sent for language detection only. Detection needs only a short window, so bounding it stops a long or noisy chunk turning into a runaway decode. It does not affect subtitle quality: a chunk confirmed as foreign is still transcribed in full. `0` sends the whole chunk. `30` matches whisper's own language-detection window. |
+| `VadModelPath` | empty | An explicit path to a Silero VAD ggml file. The plugin also writes this automatically when it downloads a model, and a path it wrote inside its own managed `vad/` directory is ignored in favour of the **Silero VAD model** selection. A path pointing anywhere else is treated as a deliberate external override and wins over that selection. |
+
+## Subtitle requests and priority
+
+Off by default. When **Allow user requests** is on, non-admin users get a **Request Subtitles** entry on the item page. Requests land as Pending and consume no CPU until an admin approves them, unless auto-approve is also on.
+
+Work is drained strongest tier first, and FIFO within a tier. Lower tiers never starve a higher one.
+
+| Setting | Default | What it does |
+|---|---|---|
+| Allow user requests | off | Master switch. While off, only admins can queue work. |
+| Auto-approve user requests | off | Enqueue a request immediately instead of holding it for an admin. |
+| Admin request tier | High | Tier for work an admin queues by hand. |
+| User request tier | Medium | Tier for an approved user request. Below admin work, above the sweep. |
+| Background sweep tier | Background | Tier for the scheduled library sweep. The weakest tier. |
+| Daily quota per user | 5 | Requests one user may make per rolling window. `0` means unlimited. |
+| Quota window | 24 hours | The rolling window the daily quota is measured over. |
+| Active cap per user | 3 | Requests one user may have in flight at once. `0` means unlimited. |
+| Items per request | 200 | Ceiling on the fan-out when a user requests a season or a series. `0` means unlimited. |
+| Global cap | 500 | Ceiling on pending requests across all users. `0` means unlimited. |
+
+Tiers are always assigned server-side from who made the request. A client cannot ask for a tier.
+
+## Settings documented elsewhere
+
+The remaining settings belong to features with their own pages.
+
+| Settings | Where |
+|---|---|
+| Whisper Binary Path, Whisper Model Path, and the recorded binary variant | [Setup guide](/docs/setup) |
+| Vocal separation: the master switch, binary and model paths, the recorded variant and quantization, overlap and chunk size | [Vocal separation](/docs/setup#vocal-separation) |
+| Remote Whisper API URL, model and key, the worker pool list, and whether the local host participates as a worker | [Remote workers](/remote-workers) |

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -72,13 +72,16 @@ Files written by older versions are still recognised. Anything containing `.gene
 | Libraries | none selected | The checkbox list under Auto-Generation scopes the sweep. **With none selected, every library is scanned.** Selecting one or more restricts the sweep to those. It applies to the scheduled task only; a manual Generate on a single item ignores it. |
 | Enable Lyrics Generation (Experimental) | Off | Includes music libraries in the sweep and writes `.lrc` lyrics next to audio tracks. Whisper is trained on speech, not singing, so accuracy varies. See [Limitations](/limitations#lyrics-generation-is-experimental). |
 | Pause generation during playback | Off | Pauses transcription while any user is playing something, and resumes when playback stops. Useful when the same box transcodes and transcribes. |
+| Skip media that already has subtitles | On | The sweep skips media that already has a usable subtitle in the language it needs, embedded or external. For the translation pass, an existing English subtitle counts as already translated. |
+| Ignore forced subtitles when skipping | On | A forced subtitle track does not count as satisfying the need. Forced tracks only cover foreign-dialogue inserts, not the whole dialogue. |
 
-## Skipping media that already has subtitles
+## Subtitle generation
+
+Whisper transcribes the speech it hears, so it can only write a subtitle in the title's own audio language. Turning that audio into English is a separate pass, covered under Translation below.
 
 | Setting | Default | What it does |
 |---|---|---|
-| Skip media that already has subtitles | On | The sweep skips media that already has a usable subtitle in the language it needs, embedded or external. For the translation pass, an existing English subtitle counts as already translated. |
-| Ignore forced subtitles when skipping | On | A forced subtitle track does not count as satisfying the need. Forced tracks only cover foreign-dialogue inserts, not the whole dialogue. |
+| Generate original-language subtitles | On | The main generate switch. Transcribes each title in its own spoken language: a Korean film gets Korean subtitles, an English film gets English. Turning it off leaves the sweep producing only whatever forced or translated output the mode calls for. A manual single-item Generate always transcribes regardless of this setting. |
 | Count image-based subtitles as present | Off | When on, image-based tracks (PGS, VOBSUB) count as an existing subtitle. Off by default because image subtitles cannot be searched or edited, so the plugin still writes a text one. |
 
 :::note[The two filters are independent]
@@ -98,13 +101,6 @@ Re-checking the filesystem for every candidate item on every scheduled run is th
 
 The **Clear skip cache now** button next to the field empties the cache immediately, so the next scheduled run re-checks every item from scratch.
 
-## Subtitle generation
-
-Whisper transcribes the speech it hears, so it can only write a subtitle in the title's own audio language. Turning that audio into English is a separate pass, covered under Translation below.
-
-| Setting | Default | What it does |
-|---|---|---|
-| Generate original-language subtitles | On | The main generate switch. Transcribes each title in its own spoken language: a Korean film gets Korean subtitles, an English film gets English. Turning it off leaves the sweep producing only whatever forced or translated output the mode calls for. A manual single-item Generate always transcribes regardless of this setting. |
 
 ## Translation to English
 
@@ -131,7 +127,7 @@ Both apply to full and translated subtitles. Neither applies to forced subtitles
 
 | Setting | Default | What it does |
 |---|---|---|
-| Use speech detection (VAD) | On | Passes `--vad` to whisper-cli with the Silero model. The model is about 865 KB and downloads automatically on first use. Local whisper-cli only: it does not apply to a remote worker, which owns its own timing, nor to forced subtitles. |
+| Use speech detection (VAD) | On | Passes `--vad` to whisper-cli with the Silero model. The model is about 885 KB and downloads automatically on first use. Local whisper-cli only: it does not apply to a remote worker, which owns its own timing, nor to forced subtitles. |
 | Align subtitles to speech (fallback) | On | Enables the FFmpeg forward snap. On its own it runs only when VAD is off. Leave it on so the fallback exists. |
 | Also align VAD / worker timestamps to speech | Off | Layers the forward snap on top of VAD output and on top of remote worker output. Turn this on if lines still appear early. Requires "Align subtitles to speech" to be on. Off by default because the energy-based detector proved unreliable on some real material and can push a few starts slightly late. |
 | Compensate audio start offset | On | Shifts every timestamp by the audio stream's start time, for containers whose audio does not begin at exactly 0:00. Applies to local and to timestamped remote output, for full and translated subtitles, not forced. |
@@ -169,17 +165,19 @@ Leave a tuning field empty and the plugin stores `-1`, which it treats as unset.
 
 A matching flag placed in **Custom Whisper Arguments** supersedes the value set here. Custom arguments are appended last and whisper-cli takes the last value it sees.
 
+The next two sections on the page, **Remote Whisper API** and **Worker Pool**, are covered in [Remote workers](/remote-workers).
+
 ## Performance and advanced
 
 These sit under **Advanced / Manual Install** on the settings page.
 
 | Setting | Default | What it does |
 |---|---|---|
-| Whisper Thread Count | `0` | CPU threads for whisper inference. `0` emits no `-t` flag, so whisper.cpp uses its own default of 4. Set it to your core count. On a 16-thread i5-14500 a 2h15m film drops from an estimated 7 hours to 1h48m. Language detection is separately capped at 4 threads whatever you set here, because per-chunk process spawning does not benefit from more. |
+| Whisper Thread Count | `0` | CPU threads for whisper inference. `0` emits no `-t` flag, so whisper.cpp uses its own default of 4. Set it to your core count. On a 16-thread i5-14500 a 2h15m film drops from an estimated 7 hours to 1h48m. Language detection is separately capped at 4 threads whatever you set here, because detection is a trivial workload that gains nothing from more parallelism and would only cause CPU spikes. |
 | Maximum subtitle line length | `0` | Maximum characters per cue, emitted as `--max-len N` together with `--split-on-word` so a cap never breaks mid-word. `0` is unset, which leaves whisper.cpp's own default of unlimited. Raise it if subtitles arrive as one enormous run-on line: broadcast subtitling caps a line near 42 characters and `47` is a good starting point. Local whisper-cli only, since a remote worker owns its own segmentation. Set `WHISPER_MAX_LEN` on the worker instead. |
 | Custom Whisper Arguments | empty | Extra space-separated arguments appended to every whisper-cli invocation, for example `--beam-size 8`. Local whisper-cli only. |
 
-Arguments the plugin manages itself are blocked from that field: the model, input file, language, thread count, max context, non-speech suppression, every output format and the output path, `--translate`, `--detect-language`, `--prompt`, the offset and duration flags, and `--vad` with `--vad-model`. The VAD tuning flags and `--max-len` are deliberately **not** blocked, so you can override those settings from here.
+Arguments the plugin manages itself are blocked from that field: the model, input file, language, thread count, max context, non-speech suppression, every output format and the output path, `--translate`, `--detect-language`, the no-timestamps flags, `--prompt`, the offset and duration flags, and `--vad` with `--vad-model`. The VAD tuning flags and `--max-len` are deliberately **not** blocked, so you can override those settings from here.
 
 ## Config file only
 
@@ -220,24 +218,26 @@ Every call to a remote worker is bounded by a deadline derived from the length o
 
 ## Subtitle requests and priority
 
-Off by default. When **Allow user requests** is on, non-admin users get a **Request Subtitles** entry on the item page. Requests land as Pending and consume no CPU until an admin approves them, unless auto-approve is also on.
+Off by default. When **Allow users to request subtitles** is on, non-admin users get a **Request Subtitles** entry on the item page. Requests land as Pending and consume no CPU until an admin approves them, unless auto-approve is also on.
 
 Work is drained strongest tier first, and FIFO within a tier. Lower tiers never starve a higher one.
 
 | Setting | Default | What it does |
 |---|---|---|
-| Allow user requests | off | Master switch. While off, only admins can queue work. |
-| Auto-approve user requests | off | Enqueue a request immediately instead of holding it for an admin. |
-| Admin request tier | High | Tier for work an admin queues by hand. |
-| User request tier | Medium | Tier for an approved user request. Below admin work, above the sweep. |
-| Background sweep tier | Background | Tier for the scheduled library sweep. The weakest tier. |
-| Daily quota per user | 5 | Requests one user may make per rolling window. `0` means unlimited. |
-| Quota window | 24 hours | The rolling window the daily quota is measured over. |
-| Active cap per user | 3 | Requests one user may have in flight at once. `0` means unlimited. |
-| Items per request | 200 | Ceiling on the fan-out when a user requests a season or a series. `0` means unlimited. |
-| Global cap | 500 | Ceiling on pending requests across all users. `0` means unlimited. |
+| Allow users to request subtitles | off | Master switch. While off, only admins can queue work. |
+| Auto-approve user requests (skip my approval) | off | Enqueue a request immediately instead of holding it for an admin. |
+| Admin request priority | High | Tier for work an admin queues by hand. |
+| User request priority | Medium | Tier for an approved user request. Below admin work, above the sweep. |
+| Background sweep priority | Background | Tier for the scheduled library sweep. The weakest tier. |
+| Requests per user per window | 5 | Requests one user may make per rolling window. `0` means unlimited. |
+| Rolling window (hours) | 24 | The rolling window the daily quota is measured over. |
+| Max active requests per user | 3 | Requests one user may have in flight at once. `0` means unlimited. |
+| Max items per request | 200 | Ceiling on the fan-out when a user requests a season or a series. The settings page enforces a minimum of 1 and rewrites anything lower back to 200. |
+| Global active request cap | 500 | Ceiling on pending and queued requests across all users. `0` means unlimited. |
 
-Tiers are always assigned server-side from who made the request. A client cannot ask for a tier.
+The last five sit behind the collapsed **User request limits (anti-abuse)** disclosure on the settings page; expand it to find them.
+
+Priorities are always assigned server-side from who made the request. A client cannot ask for one.
 
 ## Settings documented elsewhere
 

--- a/site/docs/setup.md
+++ b/site/docs/setup.md
@@ -213,6 +213,57 @@ services:
       - /mnt/user/appdata/roformer:/opt/roformer:ro   # optional custom assets on unRAID
 ```
 
+### Separation tuning (advanced)
+
+The **Separation tuning (advanced)** block sits under the two download panels and holds four fields. The Download buttons fill the two paths in for you; set them by hand only for a manual install.
+
+| Field | Default | What it does |
+|---|---|---|
+| BSRoformer binary path | empty | Absolute path to `bs_roformer-cli`, as visible to Jellyfin. |
+| BSRoformer model path | empty | Absolute path to a compatible GGUF model. |
+| Chunk overlap | `0`, meaning the model's own default | BSRoformer.cpp `--overlap`: how many times each chunk is reprocessed and blended with its neighbours to smooth the boundaries. 1 is the minimum, faster than the default and barely worse on dialogue. 2 to 4 reduce audible seams in music and multiply processing time proportionally. |
+| Chunk size (samples) | `-1`, meaning the model's own default | BSRoformer.cpp `--chunk-size`: the audio window fed to the model in one pass, in samples at 44.1 kHz. 2822400, about 64 seconds, works well on 8 GB of VRAM with the Q8_0 model. 176400, 4 seconds, cuts VRAM use at the cost of more passes. |
+
+Two more values are stored but not editable: which binary variant and which model quantization were actually downloaded. The setup page reads them back so it re-offers what you installed rather than defaulting to a GPU recommendation every time it loads.
+
+### Installing it manually {#vocal-separation-manual}
+
+Use this when the container cannot reach GitHub or Hugging Face, or when you want the files on storage the plugin does not manage.
+
+**The binary.** The plugin pins upstream BSRoformer.cpp **v0.1.0** and pulls the archive from that release. Take the same asset yourself:
+
+```text
+https://github.com/chenmozhijin/BSRoformer.cpp/releases/tag/v0.1.0
+```
+
+The assets are `.tar.xz` on Linux and macOS and `.zip` on Windows. Linux x64 has three: `BSRoformer-linux-x64-cpu.tar.xz`, `BSRoformer-linux-vulkan.tar.xz` and `BSRoformer-linux-cuda-12.9.1.tar.xz`. Extract the archive and keep its contents together, because some builds ship shared libraries next to `bs_roformer-cli` that it needs at runtime.
+
+**The model.** The downloader takes GGUF conversions of the anvuew BS-RoFormer model from [chenmozhijin/BSRoformer-GGUF](https://huggingface.co/chenmozhijin/BSRoformer-GGUF), under `anvuew/BS-RoFormer`, pinned to revision `df802a6773d25ba6ef785ff619daa3e510503168`.
+
+| File | Size | Notes |
+|---|---|---|
+| `BSRoformer-anvuew-Q4_0.gguf` | 31 MB | Lowest quality, smallest download. |
+| `BSRoformer-anvuew-Q5_1.gguf` | 40 MB | Quality and size trade-off for constrained setups. |
+| `BSRoformer-anvuew-Q8_0.gguf` | 56 MB | The recommended default. Near-FP32 separation quality at a fraction of the size. |
+| `BSRoformer-anvuew-FP16.gguf` | 102 MB | Maximum precision, marginal gain over Q8_0. |
+
+**Where they go.** When the downloader does it, both land in the plugin's data folder: the binary in `vocal-separation/bin/` and the model in `vocal-separation/models/`, so `/config/data/WhisperSubs/vocal-separation/` on a standard Docker install. A manual install can live anywhere Jellyfin can read, and the binary must be executable. Set the two paths under **Separation tuning (advanced)** and save.
+
+:::warning[unRAID: keep it off /opt]
+unRAID rebuilds its root filesystem in RAM from the flash drive on every boot, and `/opt` is part of that. Anything you put there is gone after a reboot. Keep the binary and the model under `/mnt/user/appdata` and bind-mount that into the container, as in the compose example above.
+:::
+
+### Licences {#vocal-separation-licences}
+
+WhisperSubs is GPL-3.0. It ships neither of these. Both are fetched at runtime, and both are optional, because vocal separation is off by default.
+
+| Component | Licence |
+|---|---|
+| [BSRoformer.cpp](https://github.com/chenmozhijin/BSRoformer.cpp), which provides `bs_roformer-cli` | [MIT](https://github.com/chenmozhijin/BSRoformer.cpp/blob/master/LICENSE) |
+| [anvuew BS-RoFormer](https://huggingface.co/anvuew/BS-RoFormer), the separation model | GPL-3.0 |
+
+The GGUF files the plugin downloads are quantized conversions of that anvuew model, republished by the BSRoformer.cpp author.
+
 ## Troubleshooting {#troubleshooting}
 
 ### "Missing libgomp.so.1"

--- a/site/docs/setup.md
+++ b/site/docs/setup.md
@@ -262,7 +262,7 @@ WhisperSubs is GPL-3.0. It ships neither of these. Both are fetched at runtime, 
 | [BSRoformer.cpp](https://github.com/chenmozhijin/BSRoformer.cpp), which provides `bs_roformer-cli` | [MIT](https://github.com/chenmozhijin/BSRoformer.cpp/blob/master/LICENSE) |
 | [anvuew BS-RoFormer](https://huggingface.co/anvuew/BS-RoFormer), the separation model | GPL-3.0 |
 
-The GGUF files the plugin downloads are quantized conversions of that anvuew model, republished by the BSRoformer.cpp author.
+The GGUF files the plugin downloads are quantized conversions of that anvuew model, republished by the BSRoformer.cpp author. The GGUF repository itself declares no licence, so the terms that reach you are the upstream model's.
 
 ## Troubleshooting {#troubleshooting}
 

--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -13,13 +13,19 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Running it',
       collapsed: false,
-      items: ['remote-workers'],
+      items: ['configuration', 'remote-workers'],
     },
     {
       type: 'category',
       label: 'Help',
       collapsed: false,
       items: ['diagnostics', 'limitations'],
+    },
+    {
+      type: 'category',
+      label: 'Reference',
+      collapsed: false,
+      items: ['api-and-internals'],
     },
   ],
 };


### PR DESCRIPTION
The README was 687 lines because it was the only documentation this project had. It is not any more, and most of what it carried had quietly drifted out of step with the code.

## Eleven wrong claims, each verified against the source

| Claim | Reality |
|---|---|
| Five binary variants | `Setup/BinaryCatalog.cs:10-23` ships **seven**; `cuda12-noavx` and `vulkan-noavx` appeared nowhere |
| Binary downloads work everywhere | `BinaryCatalog.cs:41-48` returns an empty list off Linux, so macOS and Windows users met an empty dropdown with no explanation |
| Seven models | `Setup/ModelCatalog.cs:5-25` ships **nine** |
| Recommended model translates | **Both** turbo models are `canTranslate: false` |
| Output files are `Movie.es.generated.srt` | `Controller/SubtitleNaming.cs:21` drops the `generated` token; those filenames are unproducible |
| 17 REST endpoints | 32 in `SubtitleController` + 4 in `SubtitleRequestController` = **36** |
| ~34 settings documented | 62 exist; the gap is now split into 6 real config-file-only tunables and 4 plugin-written state fields |
| — | User subtitle requests and filename templating were documented nowhere at all |
| Every variant needs `libgomp1` | False for the three `*-noavx` builds, compiled `-DGGML_OPENMP=OFF` |
| Vulkan needs `mesa-vulkan-drivers` | The variant is advertised for NVIDIA too, and Mesa ships no NVIDIA ICD |
| Job timeout settings on the settings page | `grep JobTimeout Web/configPage.html` returns nothing; they are config-file only |

## The one that would actually bite someone

The recommended model cannot translate. Both turbo models carry `canTranslate: false` (`ModelCatalog.cs:7-10`), and enabling translation on one only logs a warning (`SubtitleManager.cs:696-708`) before writing the **source language** into a file named `.en.translated.srt`. Nothing in the filename or Jellyfin's subtitle picker reveals that it is not English. The model table now has a `Translates` column and says which model to download instead.

## Why this stops recurring

Everything with a home on the documentation site is now a link rather than a copy. Duplication is what let these eleven drift in the first place: the code moved, the site did not exist, and the README was the only place anyone thought to look.

What stayed is what the site does not cover: the model catalogue, the config-file-only settings, and the output filename table.

687 lines to 172. Every link verified live, including all 28 URLs and the four relative paths.

Also removed `README.md:176`, which promised the AVX2 fallback covers every AVX2 build. It does not cover ROCm. The accurate version of that guidance lives at `site/docs/choosing-a-variant.md:39-43`, and the code fix is #173.