### PR TITLE
chore(release): 4.8.0.2

### DIFF
--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.8.0.1</Version>
+    <Version>4.8.0.2</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Ships the ROCm build fix from #173, which is the reason this release exists rather than waiting.

## What was broken

The ROCm job never passed `-DGGML_NATIVE=OFF`, so ggml defaulted it ON and applied `-march=native` against whatever the CI runner was. Disassembling the published `whisper-cli-linux-x64-rocm` from v4.8.0.1:

| marker | `rocm` asset | `cpu` asset (control) |
|---|---|---|
| `zmm` operands (AVX-512) | **19,940** | 0 |
| `vmovdqu64` / `vmovdqa64` | 2,262 / 1,337 | 0 / 0 |
| `vpternlogd`, `vpermt2d`, `kmovw` | 233, 89, 34 | 0, 0, 0 |

AVX-512 sits inside `ggml_cpu_fp32_to_fp16`, a core transcription path. That binary raises SIGILL on every CPU without AVX-512, which covers every AMD Zen 1 to 3 and every Intel consumer chip from 12th gen onward. Those users have AVX2, so the plugin's illegal-instruction guard would have waved them straight through.

## Why this release is needed

The fix only reaches users through a rebuilt binary. The ROCm cache key moved to `v5-avx2` in #173 precisely so this run cannot restore the broken artifact.

It does **not** reach users who already downloaded it. The setup check is a file-existence test and records only which variant was installed, never which release produced it, so an existing binary survives every upgrade. That gap is filed as #176; the variant page now tells ROCm users to re-download.

## Also included

The documentation site gained a settings reference and an API and internals page (#174), and the README dropped from 687 lines to a front door after eleven factual claims in it were corrected against the source.

## Watch for

This is the first release after #172 removed `cancel-in-progress` from the release workflow, and the first to exercise the completeness check that treats a tag with missing assets as unfinished.

Expected catalog after publishing: `4.8.0.2, 4.8.0.1, 4.8.0.0, 4.7.0.1, 4.7.0.0`.