### PR TITLE
fix: stop the .generated preset overwriting subtitles, and flag a stale binary

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -17,6 +17,15 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public string WhisperBinaryVariant { get; set; } = "";
 
+        /// <summary>
+        /// The plugin version whose release the installed whisper-cli was downloaded from. The download
+        /// URL is version-pinned, so a binary keeps whatever the release that fetched it contained: the
+        /// setup check only looks for a file on disk and would never notice a later release replacing a
+        /// broken build (issue #165 shipped a ROCm binary compiled for the CI runner's own CPU). Empty
+        /// for a manually installed binary or one downloaded before this was recorded.
+        /// </summary>
+        public string WhisperBinaryVersion { get; set; } = "";
+
         public bool EnableAutoGeneration { get; set; } = false;
 
         /// <summary>

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -154,6 +154,15 @@ namespace WhisperSubs.Setup
             var binaryOk = autoBinaryExists || configBinaryValid || inPath;
             var modelOk = autoModelPath != null || configModelValid;
 
+            // Only the auto-downloaded binary can be attributed to a release. A manual path or a
+            // PATH binary is the admin's to manage, and an empty recorded version means the download
+            // predates this tracking, so neither is flagged.
+            var pluginVersion = typeof(Plugin).Assembly.GetName().Version?.ToString() ?? string.Empty;
+            var binaryFromOlderRelease = IsBinaryFromOlderRelease(
+                isAutoDownloaded: autoBinaryExists && !configBinaryValid,
+                installedVersion: config.WhisperBinaryVersion,
+                runningVersion: pluginVersion);
+
             return new SetupStatus
             {
                 BinaryFound = binaryOk,
@@ -167,6 +176,9 @@ namespace WhisperSubs.Setup
                 Platform = GetPlatformIdentifier(),
                 SetupComplete = binaryOk && modelOk,
                 InstalledVariant = config.WhisperBinaryVariant,
+                InstalledBinaryVersion = config.WhisperBinaryVersion,
+                PluginVersion = pluginVersion,
+                BinaryFromOlderRelease = binaryFromOlderRelease,
                 Gpu = DetectGpu()
             };
         }
@@ -659,6 +671,10 @@ namespace WhisperSubs.Setup
                         // Persist the variant that actually validated (after any fallback walk) so the
                         // setup page can re-offer it instead of re-defaulting to the recommendation.
                         config.WhisperBinaryVariant = currentVariant;
+                        // Record the release this came from. The URL is version-pinned, so without this
+                        // there is no way to tell a binary from a superseded release from a current one.
+                        config.WhisperBinaryVersion =
+                            typeof(Plugin).Assembly.GetName().Version?.ToString() ?? string.Empty;
                         Plugin.Instance.SaveConfiguration();
 
                         lock (_lock)
@@ -897,6 +913,25 @@ namespace WhisperSubs.Setup
         /// These crash with SIGILL (exit 132) on CPUs that lack AVX2. The "*-noavx" builds use
         /// only SSE4.2 and are safe everywhere. ARM builds have no AVX and are always safe.
         /// </summary>
+        /// <summary>
+        /// Whether the installed binary came from an older release than the one running, which means a
+        /// binary fix shipped since then has not reached this install. Advisory only: the plugin never
+        /// silently re-downloads, matching the deliberate choice made for models.
+        /// </summary>
+        /// <remarks>
+        /// False unless the binary was auto-downloaded: a manual path or a PATH binary belongs to the
+        /// admin. False when either version is absent or unparseable, so a download predating this
+        /// tracking is never reported as stale. (Issue #176.)
+        /// </remarks>
+        internal static bool IsBinaryFromOlderRelease(bool isAutoDownloaded, string? installedVersion, string? runningVersion)
+        {
+            if (!isAutoDownloaded) return false;
+            if (string.IsNullOrWhiteSpace(installedVersion) || string.IsNullOrWhiteSpace(runningVersion)) return false;
+            if (!Version.TryParse(installedVersion, out var installed)) return false;
+            if (!Version.TryParse(runningVersion, out var running)) return false;
+            return installed < running;
+        }
+
         internal static bool VariantRequiresAvx2(string variant) => variant switch
         {
             "cpu" or "cuda12" or "vulkan" or "rocm" => true,
@@ -1016,6 +1051,19 @@ namespace WhisperSubs.Setup
         public string Platform { get; set; } = "";
         public bool SetupComplete { get; set; }
         public string InstalledVariant { get; set; } = "";
+
+        /// <summary>The plugin release the installed binary was downloaded from, empty when unknown.</summary>
+        public string InstalledBinaryVersion { get; set; } = "";
+
+        /// <summary>The plugin version running now, so a client can compare without knowing it.</summary>
+        public string PluginVersion { get; set; } = "";
+
+        /// <summary>
+        /// True when the binary was downloaded by an older release than the one running. Advisory only:
+        /// the plugin never silently re-downloads, matching the deliberate choice made for models.
+        /// </summary>
+        public bool BinaryFromOlderRelease { get; set; }
+
         public GpuInfo Gpu { get; set; } = new();
     }
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -888,18 +888,29 @@
                     if (template.indexOf('{name}') === -1) missing.push('{name}');
                     if (template.indexOf('{lang}') === -1) missing.push('{lang}');
                     if (template.indexOf('{label}') === -1) missing.push('{label}');
+
+                    var transcription = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, '') + '.srt';
+                    var translation = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, 'translated') + '.srt';
+                    var forced = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, 'forced') + '.srt';
+
+                    var problems = [];
                     if (missing.length > 0) {
-                        warning.textContent = 'Template must contain {name}, {lang} and {label} (missing ' +
-                            missing.join(', ') + '). It will fall back to the default template.';
+                        problems.push('Template must contain {name}, {lang} and {label} (missing ' +
+                            missing.join(', ') + '). It will fall back to the default template.');
+                    }
+                    // A template with no {.type}/{type} resolves the full and forced passes of the
+                    // same language to one filename, so whichever runs second overwrites the other.
+                    if (transcription === forced) {
+                        problems.push('This template gives the full and forced subtitles of a language the same ' +
+                            'filename, so one would overwrite the other. Add {.type} to keep them apart.');
+                    }
+                    if (problems.length > 0) {
+                        warning.textContent = problems.join(' ');
                         warning.style.display = '';
                     } else {
                         warning.textContent = '';
                         warning.style.display = 'none';
                     }
-
-                    var transcription = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, '') + '.srt';
-                    var translation = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, 'translated') + '.srt';
-                    var forced = WhisperSubsConfig.buildSubtitleBaseName(template, 'Episode', 'en', label, 'forced') + '.srt';
 
                     page.querySelector('#previewTranscription').textContent = 'Transcription: ' + transcription;
                     page.querySelector('#previewTranslation').textContent = 'Translation: ' + translation;
@@ -942,6 +953,15 @@
                         // Split on BOTH separators — a Windows path (D:\Whisper\whisper-cli.exe) has no
                         // '/' at all, so splitting on '/' alone rendered the entire path here. (Issue #149.)
                         text.textContent = status.BinaryPath ? status.BinaryPath.split(/[\\/]/).pop() : 'Installed';
+                        // The download URL is version-pinned and the plugin never silently replaces a
+                        // binary already on disk, so a build from a superseded release stays forever
+                        // unless the admin is told. Advisory only, never automatic (issue #176).
+                        if (status.BinaryFromOlderRelease) {
+                            icon.style.color = '#CC7B19';
+                            text.textContent += ' \u2014 downloaded by ' + status.InstalledBinaryVersion +
+                                ', now running ' + status.PluginVersion +
+                                '. Download again to pick up binary fixes from newer releases.';
+                        }
                     } else if (status.BinaryFoundInPath) {
                         icon.innerHTML = '&#9745;';
                         icon.style.color = '#CC7B19';
@@ -3015,7 +3035,7 @@
             });
 
             document.querySelector('#btnPresetKeepGenerated').addEventListener('click', function () {
-                document.querySelector('#txtSubtitleFilenameTemplate').value = '{name}.{lang}.{label}.generated';
+                document.querySelector('#txtSubtitleFilenameTemplate').value = '{name}.{lang}{.type}.{label}.generated';
                 WhisperSubsConfig.updateSubtitleNamingPreview(document.querySelector('[data-role="page"]'));
             });
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -863,12 +863,16 @@
                 // dots), {.type} becomes "."+type when type is non-empty else "", {type} becomes type or
                 // "", then ".." collapses to "." and leading/trailing "." is trimmed.
                 buildSubtitleBaseName: function (template, name, lang, label, type) {
+                    // Replacement ORDER must match Controller/SubtitleNaming.BuildBaseName: name, lang,
+                    // label, then the type tokens. They diverge otherwise whenever a substituted value
+                    // itself contains a token, and the preview would stop predicting the real filename,
+                    // which the collision warning below depends on.
                     var result = (template || '')
-                        .split('{.type}').join(type ? ('.' + type) : '')
-                        .split('{type}').join(type || '')
                         .split('{name}').join(name)
                         .split('{lang}').join(lang)
-                        .split('{label}').join(label);
+                        .split('{label}').join(label)
+                        .split('{.type}').join(type ? ('.' + type) : '')
+                        .split('{type}').join(type || '');
                     while (result.indexOf('..') !== -1) { result = result.split('..').join('.'); }
                     return result.replace(/^\.+/, '').replace(/\.+$/, '');
                 },

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -194,6 +194,17 @@ public class SetupServiceTests
         Assert.False(WhisperSetupService.IsBinaryFromOlderRelease(true, installed, "4.8.0.2"));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("   ")]
+    [InlineData("dev-build")]
+    public void IsBinaryFromOlderRelease_UnknownRunningVersionIsNeverStale(string? running)
+    {
+        // A plugin built without a parseable assembly version must not accuse every binary of being old.
+        Assert.False(WhisperSetupService.IsBinaryFromOlderRelease(true, "4.7.0.0", running));
+    }
+
     [Fact]
     public void IsBinaryFromOlderRelease_ManualBinaryIsTheAdminsToManage()
     {

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using WhisperSubs.Controller;
 using WhisperSubs.Setup;
 using Xunit;
 
@@ -169,6 +170,59 @@ public class SetupServiceTests
         // without AVX (or our detection) is steered to the compatibility builds.
         var validVariants = new[] { "cpu", "noavx", "cuda12", "cuda12-noavx", "vulkan", "vulkan-noavx", "rocm" };
         Assert.Contains(gpu.RecommendedVariant, validVariants);
+    }
+
+    // Issue #176: a version-pinned download plus a file-existence check means a binary from a
+    // superseded release survives every upgrade. These pin the advisory that surfaces it.
+    [Theory]
+    [InlineData("4.8.0.1", "4.8.0.2", true)]   // a binary fix shipped since this was fetched
+    [InlineData("4.8.0.2", "4.8.0.2", false)]  // current
+    [InlineData("4.8.0.3", "4.8.0.2", false)]  // newer than the plugin: never nag
+    [InlineData("4.7.0.0", "4.8.0.2", true)]
+    public void IsBinaryFromOlderRelease_ComparesVersions(string installed, string running, bool expected)
+    {
+        Assert.Equal(expected, WhisperSetupService.IsBinaryFromOlderRelease(true, installed, running));
+    }
+
+    [Theory]
+    [InlineData("")]      // download predates this tracking
+    [InlineData(null)]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    public void IsBinaryFromOlderRelease_UnknownVersionIsNeverStale(string? installed)
+    {
+        Assert.False(WhisperSetupService.IsBinaryFromOlderRelease(true, installed, "4.8.0.2"));
+    }
+
+    [Fact]
+    public void IsBinaryFromOlderRelease_ManualBinaryIsTheAdminsToManage()
+    {
+        // A configured path or a PATH binary is not ours to judge, even if an older version is recorded.
+        Assert.False(WhisperSetupService.IsBinaryFromOlderRelease(false, "4.7.0.0", "4.8.0.2"));
+    }
+
+    // Issue #175: a filename template with no {.type} resolves the full and forced passes of one
+    // language to a single file, so whichever runs second overwrites the other. These are the
+    // templates offered as presets in Web/configPage.html.
+    [Theory]
+    [InlineData("{name}.{lang}.{label}{.type}")]
+    [InlineData("{name}.{lang}{.type}.{label}")]
+    [InlineData("{name}.{lang}{.type}.{label}.generated")]
+    public void ShippedNamingPresets_KeepFullAndForcedApart(string template)
+    {
+        var full = SubtitleNaming.BuildBaseName(template, "Movie", "es", "WhisperSubs", "");
+        var forced = SubtitleNaming.BuildBaseName(template, "Movie", "es", "WhisperSubs", "forced");
+        Assert.NotEqual(full, forced);
+    }
+
+    [Fact]
+    public void NamingTemplateWithoutTypeToken_CollapsesFullAndForced()
+    {
+        // The defect behind #175, pinned so nobody reintroduces such a template as a preset.
+        const string noType = "{name}.{lang}.{label}.generated";
+        Assert.Equal(
+            SubtitleNaming.BuildBaseName(noType, "Movie", "es", "WhisperSubs", ""),
+            SubtitleNaming.BuildBaseName(noType, "Movie", "es", "WhisperSubs", "forced"));
     }
 
     [Theory]


### PR DESCRIPTION
Two defects that share a shape: nothing errors, nothing looks wrong, and the damage is invisible until someone goes looking.

## #175 — a preset that deletes your subtitles

**Keep .generated** set `{name}.{lang}.{label}.generated`. That template has no type token, and `SubtitleNaming.BuildBaseName` only substitutes tokens the template actually contains, so the `type` argument was never used:

| template | full | forced |
|---|---|---|
| `{name}.{lang}.{label}{.type}` (default) | `Movie.es.WhisperSubs.srt` | `Movie.es.WhisperSubs.forced.srt` |
| `{name}.{lang}.{label}.generated` (preset) | `Movie.es.WhisperSubs.generated.srt` | **`Movie.es.WhisperSubs.generated.srt`** |

In `FullAndForced` mode the two passes wrote the same path and whichever finished second destroyed the other. Forced subtitles carry only foreign-dialogue inserts, so the surviving file is wrong either way.

The preset now reads `{name}.{lang}{.type}.{label}.generated`. That keeps the `.generated.` anchor `IsPluginOwnedSubtitle` matches on, and restores the ordering the legacy names used (`Movie.es.forced.generated.srt`).

Fixing the preset does not help someone who typed their own template, so the settings page now warns whenever a template resolves the full and forced previews to one name. That tests the outcome rather than looking for a token, so it catches any template that collapses them, not just the ones missing `{.type}`.

## #176 — a fix that never reaches the people who need it

The download URL is version-pinned, but nothing recorded which release produced the binary on disk, and the setup check is a file-existence test:

```csharp
var binaryOk = autoBinaryExists || configBinaryValid || inPath;
```

So a binary from a superseded release survives every upgrade, silently. That is not hypothetical: #165 shipped a ROCm binary compiled for the CI runner's own CPU, carrying AVX-512 in a core transcription path. 4.8.0.2 fixed the build, and it reaches nobody who already downloaded the broken one.

The release is now recorded next to the variant, and the engine panel says so when the binary predates the running plugin.

It stays **advisory**. The plugin never silently re-downloads, matching the deliberate choice already made for models (`Setup/ModelCatalog.cs:37`), where a silent swap would shift segmentation under a user mid-library. Only an auto-downloaded binary is judged: a configured path or a PATH binary is the admin's, and an empty recorded version means the download predates this tracking, so neither is ever reported stale.

## Tests

The version comparison is extracted as a pure helper so it is testable, matching how this repo separates decision logic from orchestration. Eight cases cover newer, equal, older, unparseable, empty, null and the manual-binary exemption, plus three asserting the shipped presets keep full and forced apart and one pinning the collision itself so no future preset reintroduces it.

Note CI is the only place these run: this machine has no .NET 9 runtime, and a root-level `dotnet test` there exits 0 having executed nothing, so a local green would have meant nothing.

Closes #175
Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup now shows the installed whisper binary’s source release and warns when it originated from an older plugin release.
  * Subtitle filename previews now detect collisions between full and forced subtitle files.
  * The “Keep .generated” naming preset now places the subtitle type before the `.generated` suffix.

* **Bug Fixes**
  * Improved subtitle naming behavior so full and forced subtitles remain distinct when using the default presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->