### PR TITLE
chore(release): 4.8.0.3

### DIFF
--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.8.0.2</Version>
+    <Version>4.8.0.3</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Ships the two fixes from #178.

**#175** — the **Keep .generated** preset resolved the full and forced passes of one language to the same filename, so in `FullAndForced` mode whichever ran second destroyed the other, with no error and nothing visibly wrong. The preset now carries a type token, and the settings page warns whenever any template collapses those two previews, which covers hand-written templates rather than only the shipped ones.

**#176** — the engine panel now reports when the installed `whisper-cli` came from an older release than the plugin running it.

That second one is why this release matters more than its size suggests. The download URL is version-pinned and the setup check is a file-existence test, so a binary from a superseded release survives every upgrade silently. Anyone still holding the AVX-512 ROCm build that 4.8.0.2 fixed has no way to discover a fix exists. This tells them.

It stays advisory. The plugin never silently re-downloads, matching the choice already made for models where a swap would shift segmentation under a user mid-library. Only auto-downloaded binaries are judged: a configured path or a PATH binary belongs to the admin, and an unrecorded version means the download predates the tracking, so neither is ever called stale.

Expected catalog after publishing: `4.8.0.3, 4.8.0.2, 4.8.0.1, 4.8.0.0, 4.7.0.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package version to 4.8.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->